### PR TITLE
Proposal of the omission method

### DIFF
--- a/src/main/java/dev/felnull/ttsvoice/tts/TTSManager.java
+++ b/src/main/java/dev/felnull/ttsvoice/tts/TTSManager.java
@@ -224,9 +224,10 @@ public class TTSManager {
         var vt = getUserVoiceType(userId, botLocation.guildId());
 
         int max = vt.getMaxTextLength(botLocation.guildId());
-        if (text.length() >= max) text = text.substring(0, max);
-
-        if (pl - text.length() > 0) text += "、以下" + (pl - text.length()) + "文字を省略";
+        String ika = "、以下";
+        String shoryaku = "文字を省略";
+        if (text.length() >= max) text = text.substring(0, max - (ika + shoryaku).length());
+        if (pl - text.length() > 0) text += ika + (pl - text.length()) + shoryaku;
 
         return Pair.of(new LiteralSayedText(text), vt);
     }

--- a/src/main/java/dev/felnull/ttsvoice/tts/TTSManager.java
+++ b/src/main/java/dev/felnull/ttsvoice/tts/TTSManager.java
@@ -224,8 +224,9 @@ public class TTSManager {
         var vt = getUserVoiceType(userId, botLocation.guildId());
 
         int max = vt.getMaxTextLength(botLocation.guildId());
-        String ika = "、以下";
-        String shoryaku = "文字を省略";
+        //ika, shoryakuは読み上げ時の文字数を正しく調べるためにひらがなにする必要があります
+        String ika = "、いか";
+        String shoryaku = "もじをしょうりゃく";
         if (text.length() >= max) text = text.substring(0, Math.max(1, max - (ika + shoryaku).length()));
         if (pl - text.length() > 0) text += ika + (pl - text.length()) + shoryaku;
 

--- a/src/main/java/dev/felnull/ttsvoice/tts/TTSManager.java
+++ b/src/main/java/dev/felnull/ttsvoice/tts/TTSManager.java
@@ -226,7 +226,7 @@ public class TTSManager {
         int max = vt.getMaxTextLength(botLocation.guildId());
         String ika = "、以下";
         String shoryaku = "文字を省略";
-        if (text.length() >= max) text = text.substring(0, max - (ika + shoryaku).length());
+        if (text.length() >= max) text = text.substring(0, Math.max(1, max - (ika + shoryaku).length()));
         if (pl - text.length() > 0) text += ika + (pl - text.length()) + shoryaku;
 
         return Pair.of(new LiteralSayedText(text), vt);

--- a/src/main/java/dev/felnull/ttsvoice/util/DiscordUtils.java
+++ b/src/main/java/dev/felnull/ttsvoice/util/DiscordUtils.java
@@ -40,8 +40,9 @@ public class DiscordUtils {
     public static String getName(BotLocation botLocation, User user, long userId) {
         var name = mentionEscape(getName_(botLocation, user, userId));
         int maxr = Main.getServerSaveData(botLocation.guildId()).getMaxReadAroundNameLimit();
+        String ikaryaku = "いかりゃく";
         if (name.length() > maxr) {
-            name = name.substring(0, maxr) + "以下略";
+            name = name.substring(0, maxr - ikaryaku.length()) + ikaryaku;
         }
         return name;
     }

--- a/src/main/java/dev/felnull/ttsvoice/util/DiscordUtils.java
+++ b/src/main/java/dev/felnull/ttsvoice/util/DiscordUtils.java
@@ -42,7 +42,7 @@ public class DiscordUtils {
         int maxr = Main.getServerSaveData(botLocation.guildId()).getMaxReadAroundNameLimit();
         String ikaryaku = "いかりゃく";
         if (name.length() > maxr) {
-            name = name.substring(0, maxr - ikaryaku.length()) + ikaryaku;
+            name = name.substring(0, Math.max(1, maxr - ikaryaku.length())) + ikaryaku;
         }
         return name;
     }

--- a/src/main/java/dev/felnull/ttsvoice/util/DiscordUtils.java
+++ b/src/main/java/dev/felnull/ttsvoice/util/DiscordUtils.java
@@ -40,6 +40,7 @@ public class DiscordUtils {
     public static String getName(BotLocation botLocation, User user, long userId) {
         var name = mentionEscape(getName_(botLocation, user, userId));
         int maxr = Main.getServerSaveData(botLocation.guildId()).getMaxReadAroundNameLimit();
+        //ikaryakuは読み上げ時の文字数を正しく調べるためにひらがなにする必要があります
         String ikaryaku = "いかりゃく";
         if (name.length() > maxr) {
             name = name.substring(0, Math.max(1, maxr - ikaryaku.length())) + ikaryaku;


### PR DESCRIPTION
名前・文章の省略方法を変更する提案です。

例えば、「ちーむふぇるぬる」という名前を7文字に省略するとき、
今の方法だと「ちーむふぇるぬいかりゃく」となり、もとの文字数よりも増えて省略する意味がありません。

提案する方法では、「いかりゃく」を含めて7文字より長くならないようにするので、
「ちーいかりゃく」となり、もとの文字数を超えません。
これには、最大文字数の設定をするときに、「いかりゃく」が加わることを考慮しなくて済むというメリットがあります。

7文字に省略するのは現実的な例ではないので「ちーいかりゃく」と不自然に省略されますが、実際にはもっと最大文字数を大きく設定するはずので、あまり問題にはならないと思います。

メリット（上記）・デメリット（直感的でない）ある提案なので、ぜひ実装するべきだ  と言うわけではありませんが、よければ検討していただきたいです。

（実際に動かしてテストできていないので、もしマージすることになったらチェックをお願いします）