### PR TITLE
fix: Discord音声の新しい暗号化モードに対応

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,7 +17,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.mockito:mockito-junit-jupiter:5.14.2")
 
-    api("net.dv8tion:JDA:6.1.0")
+    api("net.dv8tion:JDA:6.2.0")
+    api("com.google.crypto.tink:tink:1.15.0")
     api("org.apache.commons:commons-lang3:3.19.0")
     api("com.google.code.gson:gson:2.13.2")
     api("com.google.guava:guava:33.5.0-jre")


### PR DESCRIPTION
## Summary
- JDA 6.1.0 → 6.2.0 に更新
- tink 1.15.0 依存関係を追加

## 背景
2024年11月18日以降、Discordは音声接続で新しい暗号化モード (`aead_xchacha20_poly1305_rtpsize`, `aead_aes256_gcm_rtpsize`) を必須としています。

現在のJDA 6.1.0ではこれらの暗号化モードに対応しておらず、以下のエラーが発生します：
```
[ERROR] AudioWebSocket - None of the provided encryption modes are supported: ["aead_aes256_gcm_rtpsize","aead_xchacha20_poly1305_rtpsize"]
```

JDA 6.2.0とtinkライブラリを追加することで、新しい暗号化モードに対応できます。

## Test plan
- [x] ビルドが成功することを確認
- [x] 音声チャンネルへの接続が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)