### PR TITLE
ci: GitHub Actionsのアクションを最新化

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,11 +15,11 @@ jobs:
       pull-requests: write
       checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
-          fetch-depth: 0  # a full history is required for pull request analysis
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2023.2
+        uses: JetBrains/qodana-action@v2024.3
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -20,6 +20,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2024.3
+        uses: JetBrains/qodana-action@v2023.2
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -14,30 +14,23 @@ jobs:
 
     steps:
       - name: Checkout # チェックアウト
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup JDK # JDKセットアップ
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '17'
 
       - name: Setup Gradle # Gradleセットアップ
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-home-cache-cleanup: true
-
-      - name: Check # Check
-        shell: bash
-        run: |
-          chmod +x gradlew
-          chmod -R +X gradle
-          ./gradlew check
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build # ビルド
         shell: bash
         run: |
-          ./gradlew build --stacktrace --no-daemon
+          chmod +x gradlew
+          chmod -R +X gradle
+          ./gradlew build --stacktrace


### PR DESCRIPTION
## 変更内容
- actions/checkout v3 → v4
- actions/setup-java v3 → v4
- gradle/gradle-build-action v2 → gradle/actions/setup-gradle v4
- JetBrains/qodana-action v2023.2 → v2024.3
- check + build を build に統合 (buildがcheckを含むため)
- --no-daemon 削除 (GitHub ActionsではVM使い捨てのため不要)