### PR TITLE
vnickコマンドで空引数時にリセット可能に

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/discord/command/AdminCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/AdminCommand.java
@@ -40,7 +40,7 @@ public class AdminCommand extends BaseCommand {
                         .addOptions(new OptionData(OptionType.USER, "user", "ユーザー指定")
                                 .setRequired(true))
                         .addOptions(new OptionData(OptionType.STRING, "name", "名前")
-                                .setRequired(true)))
+                                .setRequired(false)))
                 .addSubcommandGroups(new SubcommandGroupData("voice", "読み上げ音声タイプ関係")
                         .addSubcommands((new SubcommandData("change", "他人の読み上げ音声タイプを変更")
                                         .addOptions(new OptionData(OptionType.USER, "user", "ユーザー指定")
@@ -71,12 +71,12 @@ public class AdminCommand extends BaseCommand {
 
     private void vnick(SlashCommandInteractionEvent event) {
         User user = Objects.requireNonNull(event.getOption("user", OptionMapping::getAsUser));
-        String name = Objects.requireNonNull(event.getOption("name", OptionMapping::getAsString));
+        String name = event.getOption("name", OptionMapping::getAsString);
         Guild guild = Objects.requireNonNull(event.getGuild());
         LegacySaveDataLayer legacySaveDataLayer = SaveDataManager.getInstance().getLegacySaveDataLayer();
         LegacyServerUserData sud = legacySaveDataLayer.getServerUserData(guild.getIdLong(), user.getIdLong());
 
-        if ("reset".equals(name)) {
+        if (name == null || name.isBlank()) {
             sud.setNickName(null);
             event.reply(DiscordUtils.getEscapedName(event.getGuild(), user) + "の読み上げユーザ名をリセットしました。").queue();
         } else {

--- a/core/src/main/java/dev/felnull/itts/core/discord/command/VnickCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/VnickCommand.java
@@ -35,7 +35,7 @@ public class VnickCommand extends BaseCommand {
         return Commands.slash("vnick", "自分の読み上げユーザ名を変更")
                 .addOptions(new OptionData(OptionType.STRING, "name", "名前")
                         .setMaxLength(100)
-                        .setRequired(true))
+                        .setRequired(false))
                 .setContexts(InteractionContextType.GUILD)
                 .setDefaultPermissions(MEMBERS_PERMISSIONS);
     }
@@ -48,7 +48,7 @@ public class VnickCommand extends BaseCommand {
         LegacySaveDataLayer legacySaveDataLayer = SaveDataManager.getInstance().getLegacySaveDataLayer();
         LegacyServerUserData sud = legacySaveDataLayer.getServerUserData(guild.getIdLong(), event.getUser().getIdLong());
 
-        if ("reset".equals(name)) {
+        if (name == null || name.isBlank()) {
             sud.setNickName(null);
             event.reply("自分の読み上げユーザ名をリセットしました。").setEphemeral(true).queue();
         } else {


### PR DESCRIPTION
## Summary
- vnick/admin vnickコマンドのname引数をオプショナルに変更
- 引数未指定または空の場合にvnickをリセット

## Test plan
- [x] `/vnick` (引数なし) でリセットされることを確認
- [x] `/vnick name:テスト` で設定されることを確認
- [x] `/admin vnick user:@someone` (nameなし) でリセットされることを確認
- [x] `/admin vnick user:@someone name:テスト` で設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)