### PR TITLE
依存関係を更新

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("org.jetbrains.changelog") version "2.0.0"
+    id("org.jetbrains.changelog") version "2.2.1"
 }
 
 version = if (System.getenv("GITHUB_REF") != null && System.getenv("GITHUB_REF").startsWith("refs/tags/v")) {
@@ -14,9 +14,9 @@ changelog {
 
     introduction.set(
         """
-    このBOTの更新を追跡するための更新ログ。   
-    変更をコミットする場合は`Unreleased`に更新内容を追記してください。  
-    [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)に従って記述をお願い致します。  
+    このBOTの更新を追跡するための更新ログ。
+    変更をコミットする場合は`Unreleased`に更新内容を追記してください。
+    [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)に従って記述をお願い致します。
     """.trimIndent()
     )
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,7 @@ base {
 }
 
 checkstyle {
-    toolVersion = "10.12.2"
+    toolVersion = "12.3.1"
     sourceSets = listOf(project.sourceSets.getByName("main"))
 }
 
@@ -17,24 +17,23 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.mockito:mockito-junit-jupiter:5.14.2")
 
-    api("net.dv8tion:JDA:6.1.0")
-    api("org.apache.commons:commons-lang3:3.19.0")
+    api("net.dv8tion:JDA:6.2.0")
+    api("org.apache.commons:commons-lang3:3.20.0")
     api("com.google.code.gson:gson:2.13.2")
     api("com.google.guava:guava:33.5.0-jre")
     api("dev.felnull:felnull-java-library:1.75")
-    api("dev.arbjerg:lavaplayer:2.2.4")
-    api("commons-io:commons-io:2.20.0")
-    api("com.ibm.icu:icu4j:77.1")
+    api("dev.arbjerg:lavaplayer:2.2.6")
+    api("commons-io:commons-io:2.21.0")
+    api("com.ibm.icu:icu4j:78.1")
     api("com.atilika.kuromoji:kuromoji-ipadic:0.9.0")
-    api("com.zaxxer:HikariCP:5.1.0")
-    api("mysql:mysql-connector-java:8.0.32")
-    api("org.xerial:sqlite-jdbc:3.46.0.1")
+    api("com.zaxxer:HikariCP:7.0.2")
+    api("com.mysql:mysql-connector-j:9.5.0")
+    api("org.xerial:sqlite-jdbc:3.51.1.0")
     api("it.unimi.dsi:fastutil:8.5.18")
 
     api("org.jetbrains:annotations:26.0.2-1")
 
-    // api("org.apache.logging.log4j:log4j-core:3.0.0-beta3")
-    api("org.apache.logging.log4j:log4j-core:2.25.2")
+    api("org.apache.logging.log4j:log4j-core:2.25.3")
 }
 
 tasks.getByName<Test>("test") {

--- a/selfhost/build.gradle.kts
+++ b/selfhost/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-    id("com.github.johnrengelman.shadow") version "7.0.0"
+    id("com.github.johnrengelman.shadow") version "8.1.1"
     id("checkstyle")
 }
 
@@ -10,7 +10,7 @@ base {
 }
 
 checkstyle {
-    toolVersion = "10.12.2"
+    toolVersion = "12.3.1"
 }
 
 tasks.named<Jar>("jar") {


### PR DESCRIPTION
## Summary
- 各種ライブラリを最新バージョンに更新
- MySQLコネクタのアーティファクトIDを新しいものに変更

## 更新内容
| ライブラリ | 旧 | 新 |
|-----------|-----|-----|
| changelog plugin | 2.0.0 | 2.2.1 |
| shadow plugin | 7.0.0 | 8.1.1 |
| checkstyle | 10.12.2 | 12.3.1 |
| JDA | 6.1.0 | 6.2.0 |
| commons-lang3 | 3.19.0 | 3.20.0 |
| lavaplayer | 2.2.4 | 2.2.6 |
| commons-io | 2.20.0 | 2.21.0 |
| icu4j | 77.1 | 78.1 |
| HikariCP | 5.1.0 | 7.0.2 |
| mysql-connector | 8.0.32 | 9.5.0 |
| sqlite-jdbc | 3.46.0.1 | 3.51.1.0 |
| log4j-core | 2.25.2 | 2.25.3 |

## Test plan
- [x] ビルド成功を確認
- [ ] 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)