### PR TITLE
fix: 画像のみのメッセージで読み上げエラーが発生する問題を修正

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/tts/TTSManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/tts/TTSManager.java
@@ -178,6 +178,10 @@ public class TTSManager implements ITTSRuntimeUse {
      * @param message        メッセージ
      */
     public void sayChat(@NotNull Guild guild, @NotNull MessageChannel messageChannel, @Nullable Member member, @NotNull Message message) {
+        if (message.getContentRaw().isEmpty()) {
+            return;
+        }
+
         LegacySaveDataLayer legacySaveDataLayer = SaveDataManager.getInstance().getLegacySaveDataLayer();
 
         String ignoreRegex = legacySaveDataLayer.getServerData(guild.getIdLong()).getIgnoreRegex();

--- a/core/src/test/java/dev/felnull/itts/core/tts/TTSManagerTest.java
+++ b/core/src/test/java/dev/felnull/itts/core/tts/TTSManagerTest.java
@@ -1,0 +1,47 @@
+package dev.felnull.itts.core.tts;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @description TTSManagerのテスト
+ */
+@ExtendWith(MockitoExtension.class)
+class TTSManagerTest {
+
+    @Spy
+    private TTSManager ttsManager;
+
+    @Mock
+    private Guild guild;
+
+    @Mock
+    private MessageChannel messageChannel;
+
+    @Mock
+    private Member member;
+
+    @Mock
+    private Message message;
+
+    @Test
+    @DisplayName("空のメッセージの場合、sayGuildMemberTextが呼ばれない")
+    void sayChat_emptyMessage_shouldNotCallSayGuildMemberText() {
+        when(message.getContentRaw()).thenReturn("");
+
+        ttsManager.sayChat(guild, messageChannel, member, message);
+
+        verify(ttsManager, never()).sayGuildMemberText(any(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
## Summary

- 画像のみ(テキストなし)のメッセージを受信した際に `IllegalArgumentException: Text cannot be null or empty` エラーが発生していた問題を修正
- `TTSManager.sayChat()` の冒頭でメッセージ内容が空の場合は早期リターンするように変更

## Test plan

- [x] 空メッセージの読み上げスキップをテストするユニットテストを追加
- [x] 画像のみのメッセージを送信してエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)