### PR TITLE
ローカルビルド時のバージョン名を改善

### DIFF
--- a/.github/workflows/released.yml
+++ b/.github/workflows/released.yml
@@ -57,7 +57,6 @@ jobs:
           ./gradlew build --stacktrace --no-daemon
 
       - name: Publish to Maven #Mavenリポジトリに公開
-        if: ${{ secrets.MAVEN_PASSWORD != '' }}
         shell: bash
         continue-on-error: true
         run: |

--- a/.github/workflows/released.yml
+++ b/.github/workflows/released.yml
@@ -54,7 +54,14 @@ jobs:
       - name: Build #ビルド
         shell: bash
         run: |
-          ./gradlew build publish --stacktrace --no-daemon
+          ./gradlew build --stacktrace --no-daemon
+
+      - name: Publish to Maven #Mavenリポジトリに公開
+        if: ${{ secrets.MAVEN_PASSWORD != '' }}
+        shell: bash
+        continue-on-error: true
+        run: |
+          ./gradlew publish --stacktrace --no-daemon
         env:
           mavenpassword: ${{ secrets.MAVEN_PASSWORD }}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,10 @@ plugins {
 version = if (System.getenv("GITHUB_REF") != null && System.getenv("GITHUB_REF").startsWith("refs/tags/v")) {
     System.getenv("GITHUB_REF").substring("refs/tags/v".length)
 } else {
-    "NONE"
+    val gitHash = providers.exec {
+        commandLine("git", "rev-parse", "--short", "HEAD")
+    }.standardOutput.asText.get().trim()
+    "dev-$gitHash"
 }
 
 changelog {


### PR DESCRIPTION
## Summary
- ローカルビルド時のバージョン名を `NONE` から `dev-{Gitハッシュ}` 形式に変更
- どのコミットからビルドされたか追跡可能に
- CIで `build` と `publish` を分離し、forkリポジトリでもリリースJARが生成されるように変更

## Test plan
- [x] ローカルで `./gradlew build` を実行し、JARファイル名が `itts-selfhost-dev-{hash}.jar` 形式になることを確認
- [x] GitHub Actionsでのリリースビルドに影響がないことを確認