### PR TITLE
Java 25への移行

### DIFF
--- a/.github/workflows/released.yml
+++ b/.github/workflows/released.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '25'
 
       - name: Setup Gradle #Gradleセットアップ
         uses: gradle/gradle-build-action@v3
@@ -97,7 +97,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '25'
 
       - name: Setup Gradle #Gradleセットアップ
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '25'
 
       - name: Setup Gradle # Gradleセットアップ
         uses: gradle/actions/setup-gradle@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,14 @@ subprojects {
 
     group = rootProject.group
     version = rootProject.version
+
+    configure<JavaPluginExtension> {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(25))
+        }
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
+    }
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,9 +44,9 @@ tasks.withType<JavaCompile>().configureEach {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,7 @@ base {
 }
 
 checkstyle {
-    toolVersion = "10.12.2"
+    toolVersion = "10.21.4"
     sourceSets = listOf(project.sourceSets.getByName("main"))
 }
 
@@ -26,9 +26,9 @@ dependencies {
     api("commons-io:commons-io:2.20.0")
     api("com.ibm.icu:icu4j:77.1")
     api("com.atilika.kuromoji:kuromoji-ipadic:0.9.0")
-    api("com.zaxxer:HikariCP:5.1.0")
-    api("mysql:mysql-connector-java:8.0.32")
-    api("org.xerial:sqlite-jdbc:3.46.0.1")
+    api("com.zaxxer:HikariCP:6.2.1")
+    api("com.mysql:mysql-connector-j:9.1.0")
+    api("org.xerial:sqlite-jdbc:3.47.2.0")
     api("it.unimi.dsi:fastutil:8.5.18")
 
     api("org.jetbrains:annotations:26.0.2-1")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/selfhost/build.gradle.kts
+++ b/selfhost/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-    id("com.github.johnrengelman.shadow") version "7.0.0"
+    id("com.gradleup.shadow") version "8.3.6"
     id("checkstyle")
 }
 
@@ -10,7 +10,7 @@ base {
 }
 
 checkstyle {
-    toolVersion = "10.12.2"
+    toolVersion = "10.21.4"
 }
 
 tasks.named<Jar>("jar") {


### PR DESCRIPTION
## Summary
- Java 17からJava 25へ移行
- Gradle 8.0 → 8.12
- Shadow Plugin 7.0.0 → 8.3.6 (com.gradleup.shadow)
- Checkstyle 10.12.2 → 10.21.4
- HikariCP 5.1.0 → 6.2.1
- MySQL Connector 8.0.32 → 9.1.0 (com.mysql:mysql-connector-j)
- SQLite JDBC 3.46.0.1 → 3.47.2.0
- GitHub Actions java-version: 17 → 25

## Test plan
- [x] ローカルでビルド成功 (`./gradlew clean build`)
- [x] テスト全パス (`./gradlew test`)
- [x] shadowJar生成確認 (major version 69 = Java 25)
- [x] IntelliJ IDEAからの起動確認