### PR TITLE
denyコマンドの対象ユーザー取得バグを修正

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/discord/command/DenyCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/DenyCommand.java
@@ -70,7 +70,7 @@ public class DenyCommand extends BaseCommand {
         }
 
         LegacySaveDataLayer legacySaveDataLayer = SaveDataManager.getInstance().getLegacySaveDataLayer();
-        LegacyServerUserData sud = legacySaveDataLayer.getServerUserData(guild.getIdLong(), event.getUser().getIdLong());
+        LegacyServerUserData sud = legacySaveDataLayer.getServerUserData(guild.getIdLong(), user.getIdLong());
         if (!sud.isDeny()) {
             event.reply("読み上げ拒否をされていないユーザです。").setEphemeral(true).queue();
             return;
@@ -111,7 +111,7 @@ public class DenyCommand extends BaseCommand {
         }
 
         LegacySaveDataLayer legacySaveDataLayer = SaveDataManager.getInstance().getLegacySaveDataLayer();
-        LegacyServerUserData sud = legacySaveDataLayer.getServerUserData(guild.getIdLong(), event.getUser().getIdLong());
+        LegacyServerUserData sud = legacySaveDataLayer.getServerUserData(guild.getIdLong(), user.getIdLong());
         if (sud.isDeny()) {
             event.reply("すでに読み上げ拒否をされているユーザです。").setEphemeral(true).queue();
             return;

--- a/core/src/main/java/dev/felnull/itts/core/savedata/repository/impl/KeyData.java
+++ b/core/src/main/java/dev/felnull/itts/core/savedata/repository/impl/KeyData.java
@@ -97,7 +97,7 @@ final class KeyData<T> extends SaveDataBase {
     private T getKeyFromDB(Connection connection, int keyId) throws SQLException {
         DAO.KeyTable<T> keyTable = keyTableProvider.apply(dao());
         Optional<T> key = keyTable.selectKey(connection, keyId);
-        return key.orElseThrow();
+        return key.orElse(null);
     }
 
 }

--- a/core/src/main/java/dev/felnull/itts/core/tts/TTSManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/tts/TTSManager.java
@@ -241,6 +241,10 @@ public class TTSManager implements ITTSRuntimeUse {
 
         long userId = user.getIdLong();
 
+        if (legacySaveDataLayer.getServerUserData(guildId, userId).isDeny()) {
+            return;
+        }
+
         TTSInstance ti = getTTSInstance(guildId);
         if (ti == null || ti.getTextChannel() != textChannelId) {
             return;


### PR DESCRIPTION
## Summary
- denyコマンドで対象ユーザーではなくコマンド実行者のデータを参照していたバグを修正
- 存在しないキーIDで例外がスローされる問題を修正 (nullを返すように変更)
- deny状態のユーザーのメッセージが読み上げられていた問題を修正

## Test plan
- [ ] denyコマンドで他ユーザーを指定した際、正しく対象ユーザーのdeny状態が確認されること
- [ ] deny状態のユーザーのメッセージが読み上げられないこと
- [ ] 存在しないキーIDを参照した際に例外が発生しないこと