### PR TITLE
無効なTTSエンジンの初期化をスキップ

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/voice/VoiceManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/voice/VoiceManager.java
@@ -63,8 +63,8 @@ public class VoiceManager implements ITTSBaseManager {
         return CompletableFuture.allOf(
                         voicevoxManager.init(),
                         coeiroinkManager.init(),
-                        sharevoxManager.init()).
-                thenAcceptAsync(v -> {
+                        sharevoxManager.init())
+                .thenAcceptAsync(v -> {
                     registerVoiceTypes(voiceTextManager::getVoiceTypes);
                     registerVoiceTypes(voicevoxManager::getAvailableVoiceTypes);
                     registerVoiceTypes(coeiroinkManager::getAvailableVoiceTypes);

--- a/core/src/main/java/dev/felnull/itts/core/voice/coeiroink/CoeiroinkManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/voice/coeiroink/CoeiroinkManager.java
@@ -76,6 +76,9 @@ public class CoeiroinkManager {
      * @return 初期化の非同期CompletableFuture
      */
     public CompletableFuture<?> init() {
+        if (!getConfig().isEnable()) {
+            return CompletableFuture.completedFuture(null);
+        }
         return balancer.init();
     }
 

--- a/core/src/main/java/dev/felnull/itts/core/voice/voicevox/VoicevoxManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/voice/voicevox/VoicevoxManager.java
@@ -77,6 +77,9 @@ public class VoicevoxManager {
      * @return 初期化の非同期CompletableFuture
      */
     public CompletableFuture<?> init() {
+        if (!getConfig().isEnable()) {
+            return CompletableFuture.completedFuture(null);
+        }
         return balancer.init();
     }
 


### PR DESCRIPTION
## Summary
- 設定で無効にしているTTSエンジンが起動時にURL確認を行わないように修正
- 各マネージャーの`init()`で`isEnable()`をチェックし、無効な場合は即座に完了

## Test plan
- [ ] voicevox/sharevox/coeiroinkを無効にした状態で起動し、ログに「Unavailable」が出ないことを確認