### PR TITLE
入力バリデーションの強化

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/dict/ServerDictionary.java
+++ b/core/src/main/java/dev/felnull/itts/core/dict/ServerDictionary.java
@@ -11,7 +11,9 @@ import org.jetbrains.annotations.Unmodifiable;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * サーバー辞書
@@ -50,7 +52,15 @@ public class ServerDictionary extends RegexReplaceBaseDictionary implements ITTS
     protected @NotNull Map<Pattern, Function<String, String>> getReplaces(long guildId) {
         LegacySaveDataLayer legacySaveDataLayer = SaveDataManager.getInstance().getLegacySaveDataLayer();
         return legacySaveDataLayer.getAllServerDictData(guildId).stream()
-                .map(n -> Pair.of(Pattern.compile(n.getTarget()), n.getRead()))
+                .flatMap(n -> {
+                    try {
+                        Pattern pattern = Pattern.compile(n.getTarget());
+                        return Stream.of(Pair.of(pattern, n.getRead()));
+                    } catch (PatternSyntaxException e) {
+                        getITTSLogger().warn("Invalid regex pattern in server dict: {}", n.getTarget());
+                        return Stream.empty();
+                    }
+                })
                 .collect(Collectors.toMap(Pair::getLeft, patternStringPair -> n -> patternStringPair.getRight()));
     }
 }

--- a/core/src/main/java/dev/felnull/itts/core/discord/command/AdminCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/AdminCommand.java
@@ -79,6 +79,8 @@ public class AdminCommand extends BaseCommand {
         if (name == null) {
             sud.setNickName(null);
             event.reply(DiscordUtils.getEscapedName(event.getGuild(), user) + "の読み上げユーザ名をリセットしました。").queue();
+        } else if (name.isBlank()) {
+            event.reply("名前を空にすることはできません。リセットするには名前を指定せずに実行してください。").setEphemeral(true).queue();
         } else {
             sud.setNickName(name);
             event.reply(DiscordUtils.getEscapedName(event.getGuild(), user) + "の読み上げユーザ名を変更しました。").queue();

--- a/core/src/main/java/dev/felnull/itts/core/discord/command/ConfigCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/ConfigCommand.java
@@ -5,6 +5,7 @@ import dev.felnull.itts.core.savedata.SaveDataManager;
 import dev.felnull.itts.core.savedata.legacy.LegacySaveDataLayer;
 import dev.felnull.itts.core.savedata.legacy.LegacyServerData;
 import dev.felnull.itts.core.savedata.repository.ServerData;
+import dev.felnull.itts.core.util.PatternValidator;
 import dev.felnull.itts.core.voice.VoiceCategory;
 import dev.felnull.itts.core.voice.VoiceManager;
 import dev.felnull.itts.core.voice.VoiceType;
@@ -171,6 +172,13 @@ public class ConfigCommand extends BaseCommand {
         Guild guild = Objects.requireNonNull(event.getGuild());
 
         String op = Objects.requireNonNull(event.getOption("regex", OptionMapping::getAsString));
+
+        PatternValidator.ValidationResult validationResult = PatternValidator.validate(op);
+        if (!validationResult.valid()) {
+            event.reply(validationResult.error()).setEphemeral(true).queue();
+            return;
+        }
+
         LegacySaveDataLayer legacySaveDataLayer = SaveDataManager.getInstance().getLegacySaveDataLayer();
         LegacyServerData sd = legacySaveDataLayer.getServerData(guild.getIdLong());
 

--- a/core/src/main/java/dev/felnull/itts/core/discord/command/DenyCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/DenyCommand.java
@@ -92,7 +92,6 @@ public class DenyCommand extends BaseCommand {
             return;
         }
 
-        MessageCreateBuilder msg = new MessageCreateBuilder().addContent("読み上げ拒否されたユーザ一覧\n");
         StringBuilder sb = new StringBuilder();
 
         JDA jda = event.getJDA();
@@ -103,7 +102,15 @@ public class DenyCommand extends BaseCommand {
                 sb.append(DiscordUtils.getEscapedName(guild, user)).append("\n");
             }
         }
-        msg.addContent("``" + sb + "``");
+
+        if (sb.isEmpty()) {
+            event.reply("読み上げ拒否されたユーザの情報を取得できませんでした。").setEphemeral(true).queue();
+            return;
+        }
+
+        MessageCreateBuilder msg = new MessageCreateBuilder()
+                .addContent("読み上げ拒否されたユーザ一覧\n")
+                .addContent("```\n" + sb + "```");
         event.reply(msg.build()).setEphemeral(true).queue();
     }
 

--- a/core/src/main/java/dev/felnull/itts/core/discord/command/VnickCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/VnickCommand.java
@@ -51,6 +51,8 @@ public class VnickCommand extends BaseCommand {
         if (name == null) {
             sud.setNickName(null);
             event.reply("自分の読み上げユーザ名をリセットしました。").setEphemeral(true).queue();
+        } else if (name.isBlank()) {
+            event.reply("名前を空にすることはできません。リセットするには名前を指定せずに実行してください。").setEphemeral(true).queue();
         } else {
             sud.setNickName(name);
             event.reply("自分の読み上げユーザ名を変更しました。").setEphemeral(true).queue();

--- a/core/src/main/java/dev/felnull/itts/core/tts/TTSManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/tts/TTSManager.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * TTS管理
@@ -186,9 +187,13 @@ public class TTSManager implements ITTSRuntimeUse {
 
         String ignoreRegex = legacySaveDataLayer.getServerData(guild.getIdLong()).getIgnoreRegex();
         if (ignoreRegex != null) {
-            Pattern ignorePattern = Pattern.compile(ignoreRegex);
-            if (ignorePattern.matcher(message.getContentDisplay()).matches()) {
-                return;
+            try {
+                Pattern ignorePattern = Pattern.compile(ignoreRegex);
+                if (ignorePattern.matcher(message.getContentDisplay()).matches()) {
+                    return;
+                }
+            } catch (PatternSyntaxException e) {
+                getITTSLogger().warn("Invalid ignore regex for guild {}: {}", guild.getIdLong(), ignoreRegex);
             }
         }
 

--- a/core/src/main/java/dev/felnull/itts/core/util/PatternValidator.java
+++ b/core/src/main/java/dev/felnull/itts/core/util/PatternValidator.java
@@ -1,0 +1,94 @@
+package dev.felnull.itts.core.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * 正規表現バリデーションユーティリティ
+ */
+public final class PatternValidator {
+
+    /**
+     * ReDoS脆弱性を持つ可能性のあるパターン
+     * ネストされた量子 (例: (a+)+, (a*)*) を検出
+     */
+    private static final Pattern REDOS_PATTERN = Pattern.compile(
+            "\\([^)]*[+*][^)]*\\)[+*]|\\([^)]*\\|[^)]*\\)[+*]"
+    );
+
+    private PatternValidator() {
+    }
+
+    /**
+     * 正規表現の構文を検証する
+     *
+     * @param regex 検証する正規表現
+     * @return 検証結果
+     */
+    @NotNull
+    public static ValidationResult validate(@NotNull String regex) {
+        try {
+            Pattern pattern = Pattern.compile(regex);
+
+            if (isPotentiallyDangerous(regex)) {
+                return ValidationResult.failure("この正規表現はパフォーマンス上の問題を引き起こす可能性があります");
+            }
+
+            return ValidationResult.success(pattern);
+        } catch (PatternSyntaxException e) {
+            return ValidationResult.failure("無効な正規表現です: " + e.getDescription());
+        }
+    }
+
+    /**
+     * 正規表現がReDoS脆弱性を持つ可能性があるかチェックする
+     *
+     * @param regex チェックする正規表現
+     * @return 危険な可能性がある場合はtrue
+     */
+    public static boolean isPotentiallyDangerous(@NotNull String regex) {
+        return REDOS_PATTERN.matcher(regex).find();
+    }
+
+    /**
+     * 正規表現バリデーションの結果
+     *
+     * @param valid   有効かどうか
+     * @param pattern コンパイル済みPattern (有効な場合のみ)
+     * @param error   エラーメッセージ (無効な場合のみ)
+     */
+    public record ValidationResult(boolean valid, Pattern pattern, String error) {
+
+        /**
+         * 成功結果を作成
+         *
+         * @param pattern コンパイル済みPattern
+         * @return 成功結果
+         */
+        public static ValidationResult success(@NotNull Pattern pattern) {
+            return new ValidationResult(true, pattern, null);
+        }
+
+        /**
+         * 失敗結果を作成
+         *
+         * @param error エラーメッセージ
+         * @return 失敗結果
+         */
+        public static ValidationResult failure(@NotNull String error) {
+            return new ValidationResult(false, null, error);
+        }
+
+        /**
+         * Patternを取得 (成功時のみ)
+         *
+         * @return コンパイル済みPattern
+         */
+        public Optional<Pattern> getPattern() {
+            return Optional.ofNullable(pattern);
+        }
+    }
+}

--- a/core/src/main/java/dev/felnull/itts/core/voice/coeiroink/CoeiroinkManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/voice/coeiroink/CoeiroinkManager.java
@@ -115,10 +115,20 @@ public class CoeiroinkManager {
                 .timeout(Duration.of(3000, ChronoUnit.MILLIS))
                 .build();
         HttpResponse<InputStream> rep = hc.send(req, HttpResponse.BodyHandlers.ofInputStream());
+
+        int statusCode = rep.statusCode();
+        if (statusCode != 200) {
+            throw new IOException(name + " API error: HTTP " + statusCode);
+        }
+
         JsonArray ja;
 
         try (InputStream stream = new BufferedInputStream(rep.body()); Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
             ja = GSON.fromJson(reader, JsonArray.class);
+        }
+
+        if (ja == null) {
+            throw new IOException(name + " API returned invalid JSON response");
         }
 
         ImmutableList.Builder<CoeiroinkSpeaker> speakerBuilder = new ImmutableList.Builder<>();

--- a/core/src/main/java/dev/felnull/itts/core/voice/voicevox/VoicevoxManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/voice/voicevox/VoicevoxManager.java
@@ -116,10 +116,20 @@ public class VoicevoxManager {
                 .timeout(Duration.of(3000, ChronoUnit.MILLIS))
                 .build();
         HttpResponse<InputStream> rep = hc.send(req, HttpResponse.BodyHandlers.ofInputStream());
+
+        int statusCode = rep.statusCode();
+        if (statusCode != 200) {
+            throw new IOException(name + " API error: HTTP " + statusCode);
+        }
+
         JsonArray ja;
 
         try (InputStream stream = new BufferedInputStream(rep.body()); Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
             ja = GSON.fromJson(reader, JsonArray.class);
+        }
+
+        if (ja == null) {
+            throw new IOException(name + " API returned invalid JSON response");
         }
 
         ImmutableList.Builder<VoicevoxSpeaker> speakerBuilder = new ImmutableList.Builder<>();
@@ -142,9 +152,21 @@ public class VoicevoxManager {
                     .build();
             HttpResponse<InputStream> rep = hc.send(req, HttpResponse.BodyHandlers.ofInputStream());
 
-            try (InputStream stream = new BufferedInputStream(rep.body()); Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
-                return GSON.fromJson(reader, JsonObject.class);
+            int statusCode = rep.statusCode();
+            if (statusCode != 200) {
+                throw new IOException(name + " audio_query API error: HTTP " + statusCode);
             }
+
+            JsonObject result;
+            try (InputStream stream = new BufferedInputStream(rep.body()); Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+                result = GSON.fromJson(reader, JsonObject.class);
+            }
+
+            if (result == null) {
+                throw new IOException(name + " audio_query API returned invalid JSON response");
+            }
+
+            return result;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/core/src/test/java/dev/felnull/itts/core/dict/DictionaryManagerTest.java
+++ b/core/src/test/java/dev/felnull/itts/core/dict/DictionaryManagerTest.java
@@ -1,0 +1,104 @@
+package dev.felnull.itts.core.dict;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * DictionaryManagerのバリデーションテスト
+ */
+public class DictionaryManagerTest {
+
+    private final DictionaryManager dictionaryManager = new DictionaryManager();
+
+    @Nested
+    @DisplayName("serverDictLoadFromJson()のバリデーションテスト")
+    class ServerDictLoadFromJsonTests {
+
+        @Test
+        @DisplayName("バージョンが異なる場合は例外をスロー")
+        void invalidVersionThrowsException() {
+            JsonObject jo = new JsonObject();
+            jo.addProperty("version", 999);
+            JsonObject entry = new JsonObject();
+            entry.addProperty("test", "テスト");
+            jo.add("entry", entry);
+
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () ->
+                    dictionaryManager.serverDictLoadFromJson(jo, 123456L, false));
+            Assertions.assertEquals("Unsupported dictionary file version", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("versionフィールドがない場合は例外をスロー")
+        void missingVersionThrowsException() {
+            JsonObject jo = new JsonObject();
+            JsonObject entry = new JsonObject();
+            entry.addProperty("test", "テスト");
+            jo.add("entry", entry);
+
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () ->
+                    dictionaryManager.serverDictLoadFromJson(jo, 123456L, false));
+            Assertions.assertEquals("Unsupported dictionary file version", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("entryフィールドがない場合は例外をスロー")
+        void missingEntryFieldThrowsException() {
+            JsonObject jo = new JsonObject();
+            jo.addProperty("version", 0);
+
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () ->
+                    dictionaryManager.serverDictLoadFromJson(jo, 123456L, false));
+            Assertions.assertEquals("Invalid dictionary file format", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("entryがオブジェクトでない場合は例外をスロー")
+        void entryNotObjectThrowsException() {
+            JsonObject jo = new JsonObject();
+            jo.addProperty("version", 0);
+            jo.addProperty("entry", "not an object");
+
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () ->
+                    dictionaryManager.serverDictLoadFromJson(jo, 123456L, false));
+            Assertions.assertEquals("Invalid dictionary file format", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("エントリ数が上限を超える場合は例外をスロー")
+        void tooManyEntriesThrowsException() {
+            JsonObject jo = new JsonObject();
+            jo.addProperty("version", 0);
+            JsonObject entry = new JsonObject();
+
+            for (int i = 0; i <= 1000; i++) {
+                entry.addProperty("word" + i, "読み" + i);
+            }
+            jo.add("entry", entry);
+
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () ->
+                    dictionaryManager.serverDictLoadFromJson(jo, 123456L, false));
+            Assertions.assertTrue(exception.getMessage().contains("Dictionary entry count exceeds limit"));
+        }
+
+        @ParameterizedTest
+        @DisplayName("負のバージョン番号でも例外をスロー")
+        @ValueSource(ints = {-1, -100, Integer.MIN_VALUE})
+        void negativeVersionThrowsException(int version) {
+            JsonObject jo = new JsonObject();
+            jo.addProperty("version", version);
+            JsonObject entry = new JsonObject();
+            entry.addProperty("test", "テスト");
+            jo.add("entry", entry);
+
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () ->
+                    dictionaryManager.serverDictLoadFromJson(jo, 123456L, false));
+            Assertions.assertEquals("Unsupported dictionary file version", exception.getMessage());
+        }
+    }
+}

--- a/core/src/test/java/dev/felnull/itts/core/util/PatternValidatorTest.java
+++ b/core/src/test/java/dev/felnull/itts/core/util/PatternValidatorTest.java
@@ -1,0 +1,157 @@
+package dev.felnull.itts.core.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+/**
+ * PatternValidatorのテストクラス
+ */
+public class PatternValidatorTest {
+
+    @Nested
+    @DisplayName("validate()メソッドのテスト")
+    class ValidateTests {
+
+        @ParameterizedTest
+        @DisplayName("有効な正規表現が成功を返す")
+        @ValueSource(strings = {
+                "^[a-z]+$",
+                "[0-9]{3}-[0-9]{4}",
+                "hello",
+                "\\d+",
+                "a*b+c?",
+                "^(foo|bar)$",
+                "[A-Za-z0-9_]+",
+                "\\w+@\\w+\\.\\w+",
+                "(?:abc)+",
+                "\\p{L}+"
+        })
+        void validPatternsReturnSuccess(String regex) {
+            PatternValidator.ValidationResult result = PatternValidator.validate(regex);
+            Assertions.assertTrue(result.valid());
+            Assertions.assertNotNull(result.pattern());
+            Assertions.assertNull(result.error());
+            Assertions.assertTrue(result.getPattern().isPresent());
+        }
+
+        @ParameterizedTest
+        @DisplayName("無効な構文がエラーを返す")
+        @MethodSource("invalidPatterns")
+        void invalidSyntaxReturnsError(String regex, String expectedErrorContains) {
+            PatternValidator.ValidationResult result = PatternValidator.validate(regex);
+            Assertions.assertFalse(result.valid());
+            Assertions.assertNull(result.pattern());
+            Assertions.assertNotNull(result.error());
+            Assertions.assertTrue(result.error().contains("無効な正規表現です"));
+            Assertions.assertTrue(result.getPattern().isEmpty());
+        }
+
+        private static Stream<Arguments> invalidPatterns() {
+            return Stream.of(
+                    Arguments.of("[a-z", "Unclosed character class"),
+                    Arguments.of("(abc", "Unclosed group"),
+                    Arguments.of("(?P<name>", "Unknown inline modifier"),
+                    Arguments.of("*abc", "Dangling meta character"),
+                    Arguments.of("+abc", "Dangling meta character"),
+                    Arguments.of("?abc", "Dangling meta character"),
+                    Arguments.of("\\", "Unexpected internal error"),
+                    Arguments.of("[z-a]", "Illegal character range")
+            );
+        }
+
+        @ParameterizedTest
+        @DisplayName("ReDoS脆弱性パターンがエラーを返す")
+        @ValueSource(strings = {
+                "(a+)+",
+                "(a*)*",
+                "(a+)*",
+                "(a*)+",
+                "(x+)+b",
+                "(a|b)+",
+                "(a|b)*",
+                "(x|y)+z"
+        })
+        void redosPatternsReturnError(String regex) {
+            PatternValidator.ValidationResult result = PatternValidator.validate(regex);
+            Assertions.assertFalse(result.valid());
+            Assertions.assertNull(result.pattern());
+            Assertions.assertNotNull(result.error());
+            Assertions.assertTrue(result.error().contains("パフォーマンス上の問題"));
+        }
+    }
+
+    @Nested
+    @DisplayName("isPotentiallyDangerous()メソッドのテスト")
+    class IsPotentiallyDangerousTests {
+
+        @ParameterizedTest
+        @DisplayName("危険なパターンを検出する")
+        @ValueSource(strings = {
+                "(a+)+",
+                "(a*)*",
+                "(a+)*",
+                "(a*)+",
+                "(x+)+b",
+                "(a|b)+",
+                "(a|b)*",
+                "(foo|bar)*"
+        })
+        void detectsDangerousPatterns(String regex) {
+            Assertions.assertTrue(PatternValidator.isPotentiallyDangerous(regex));
+        }
+
+        @ParameterizedTest
+        @DisplayName("安全なパターンは検出しない")
+        @ValueSource(strings = {
+                "^[a-z]+$",
+                "[0-9]{3}-[0-9]{4}",
+                "hello",
+                "\\d+",
+                "a+b+c+",
+                "^(foo|bar)$",
+                "[A-Za-z0-9_]+",
+                "\\w+@\\w+\\.\\w+",
+                "(?:abc)",
+                "a{1,10}"
+        })
+        void safePatternNotDetected(String regex) {
+            Assertions.assertFalse(PatternValidator.isPotentiallyDangerous(regex));
+        }
+    }
+
+    @Nested
+    @DisplayName("ValidationResultのテスト")
+    class ValidationResultTests {
+
+        @ParameterizedTest
+        @DisplayName("成功結果が正しく作成される")
+        @ValueSource(strings = {"abc", "\\d+", "[a-z]+"})
+        void successResultCreatedCorrectly(String regex) {
+            PatternValidator.ValidationResult result = PatternValidator.ValidationResult.success(
+                    java.util.regex.Pattern.compile(regex)
+            );
+            Assertions.assertTrue(result.valid());
+            Assertions.assertNotNull(result.pattern());
+            Assertions.assertNull(result.error());
+            Assertions.assertEquals(regex, result.pattern().pattern());
+        }
+
+        @ParameterizedTest
+        @DisplayName("失敗結果が正しく作成される")
+        @ValueSource(strings = {"エラー1", "エラー2", "無効な正規表現です"})
+        void failureResultCreatedCorrectly(String errorMessage) {
+            PatternValidator.ValidationResult result = PatternValidator.ValidationResult.failure(errorMessage);
+            Assertions.assertFalse(result.valid());
+            Assertions.assertNull(result.pattern());
+            Assertions.assertEquals(errorMessage, result.error());
+            Assertions.assertTrue(result.getPattern().isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 正規表現バリデーションユーティリティ (PatternValidator) を追加し、ReDoS脆弱性を検出
- 各コマンドに入力バリデーションを追加 (空白チェック、長さ制限、正規表現検証)
- Voice API レスポンスのバリデーションを強化
- 辞書アップロード時のファイルサイズ・エントリ数制限を追加

## Test plan
- [ ] `./gradlew :core:test` が成功することを確認
- [ ] 辞書に無効な正規表現を登録しようとするとエラーになることを確認
- [ ] 1MB超のファイルをアップロードしようとするとエラーになることを確認