### PR TITLE
Discordコマンドハンドラのバグ修正

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/discord/command/DenyCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/DenyCommand.java
@@ -7,6 +7,7 @@ import dev.felnull.itts.core.util.DiscordUtils;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionContextType;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -92,26 +93,33 @@ public class DenyCommand extends BaseCommand {
             return;
         }
 
-        StringBuilder sb = new StringBuilder();
+        event.deferReply(true).queue();
 
         JDA jda = event.getJDA();
 
-        for (Long deny : denyUsers) {
-            User user = jda.retrieveUserById(deny).complete();
-            if (user != null) {
-                sb.append(DiscordUtils.getEscapedName(guild, user)).append("\n");
+        List<RestAction<User>> fetches = denyUsers.stream()
+                .<RestAction<User>>map(jda::retrieveUserById)
+                .toList();
+
+        RestAction.allOf(fetches).queue(users -> {
+            StringBuilder sb = new StringBuilder();
+
+            for (User user : users) {
+                if (user != null) {
+                    sb.append(DiscordUtils.getEscapedName(guild, user)).append("\n");
+                }
             }
-        }
 
-        if (sb.isEmpty()) {
-            event.reply("読み上げ拒否されたユーザの情報を取得できませんでした。").setEphemeral(true).queue();
-            return;
-        }
+            if (sb.isEmpty()) {
+                event.getHook().sendMessage("読み上げ拒否されたユーザの情報を取得できませんでした。").setEphemeral(true).queue();
+                return;
+            }
 
-        MessageCreateBuilder msg = new MessageCreateBuilder()
-                .addContent("読み上げ拒否されたユーザ一覧\n")
-                .addContent("```\n" + sb + "```");
-        event.reply(msg.build()).setEphemeral(true).queue();
+            MessageCreateBuilder msg = new MessageCreateBuilder()
+                    .addContent("読み上げ拒否されたユーザ一覧\n")
+                    .addContent("```\n" + sb + "```");
+            event.getHook().sendMessage(msg.build()).setEphemeral(true).queue();
+        });
     }
 
     private void add(SlashCommandInteractionEvent event) {

--- a/core/src/main/java/dev/felnull/itts/core/discord/command/DictCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/DictCommand.java
@@ -217,8 +217,20 @@ public class DictCommand extends BaseCommand {
 
                 replayEmbedBuilder.setTitle("登録された単語と読み");
 
-                for (LegacyDictData dictData : ret) {
-                    addDictWordAndReadingField(replayEmbedBuilder, dictData.getTarget(), dictData.getRead());
+                ret.stream()
+                        .limit(MessageEmbed.MAX_FIELD_AMOUNT)
+                        .forEach(dictData -> addDictWordAndReadingField(replayEmbedBuilder, dictData.getTarget(), dictData.getRead()));
+
+                if (ret.size() >= 2) {
+                    StringBuilder footerSb = new StringBuilder();
+                    footerSb.append(String.format("計%d個", ret.size()));
+
+                    int omit = ret.size() - MessageEmbed.MAX_FIELD_AMOUNT;
+                    if (omit > 0) {
+                        footerSb.append(String.format(" (%d個省略)", omit));
+                    }
+
+                    replayEmbedBuilder.setFooter(footerSb.toString());
                 }
 
                 event.getHook().sendMessageEmbeds(replayEmbedBuilder.build()).addContent(overwrite ? "以下の単語の読みを上書き登録しました" : "以下の単語の読みを登録しました").queue();
@@ -250,10 +262,13 @@ public class DictCommand extends BaseCommand {
             getDictionaryManager().serverDictSaveToJson(jo, guildId);
             return GSON.toJson(jo).getBytes(StandardCharsets.UTF_8);
 
-        }, getHeavyExecutor()).thenAcceptAsync(data -> {
-
-            event.getHook().sendFiles(FileUpload.fromData(data, guildId + "_dict.json")).setEphemeral(true).queue();
-
+        }, getHeavyExecutor()).whenCompleteAsync((data, error) -> {
+            if (error == null) {
+                event.getHook().sendFiles(FileUpload.fromData(data, guildId + "_dict.json")).setEphemeral(true).queue();
+            } else {
+                getITTSLogger().error("Dictionary download failure", error);
+                event.getHook().sendMessage("辞書ファイルのダウンロード中にエラーが発生しました").setEphemeral(true).queue();
+            }
         }, getAsyncExecutor());
     }
 
@@ -323,13 +338,13 @@ public class DictCommand extends BaseCommand {
         String w;
         String r;
 
-        if (word.length() < MAX_FIELD_TEXT_LENGTH) {
+        if (word.length() <= MAX_FIELD_TEXT_LENGTH) {
             w = "` " + word.replace("\n", "\\n") + " `";
         } else {
             w = "` " + word.substring(0, MAX_FIELD_TEXT_LENGTH).replace("\n", "\\n") + "... `";
         }
 
-        if (reading.length() < MAX_FIELD_TEXT_LENGTH) {
+        if (reading.length() <= MAX_FIELD_TEXT_LENGTH) {
             r = "```" + reading.replace("```", "\\```") + "```";
         } else {
             r = "```" + reading.substring(0, MAX_FIELD_TEXT_LENGTH).replace("```", "\\```") + "... ```";

--- a/core/src/main/java/dev/felnull/itts/core/discord/command/LeaveCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/LeaveCommand.java
@@ -63,7 +63,7 @@ public class LeaveCommand extends BaseCommand {
             if (reconnectChannelPair != null) {
                 AudioChannel audioChannel = event.getJDA().getVoiceChannelById(reconnectChannelPair.speakAudioChannel());
                 if (audioChannel != null) {
-                    event.reply(audioChannel.getAsMention() + "から切断します。").queue();
+                    event.reply(audioChannel.getAsMention() + "への再接続予約を取り消しました。").queue();
                     botStateData.setReconnectChannelPair(null);
                     reconnectFlg = true;
                 }

--- a/core/src/main/java/dev/felnull/itts/core/discord/command/ReconnectCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/ReconnectCommand.java
@@ -53,7 +53,7 @@ public class ReconnectCommand extends BaseCommand {
                 }
 
                 getTTSManager().setReadAroundChannel(event.getGuild(), event.getChannel());
-                audioManager.openAudioConnection(connectedChannel.asVoiceChannel());
+                audioManager.openAudioConnection(connectedChannel);
             }, getAsyncExecutor());
         } else {
             event.reply("現在VCに接続していません。").setEphemeral(true).queue();


### PR DESCRIPTION
## Summary
- DenyCommand.showのブロッキングREST呼び出しをdeferReply+RestAction.allOfで非同期化
- ReconnectCommandでStageチャンネル使用時のIllegalStateExceptionを修正
- DictCommand.uploadのEmbedフィールド数上限(25)超過時のクラッシュを修正
- DictCommand.downloadにエラーハンドラを追加(deferred reply放置を防止)
- DictCommand.addDictWordAndReadingFieldのoff-by-one修正(境界値125文字の不要な切り詰め)
- LeaveCommandの再接続ペアクリア時の誤メッセージを修正

## Test plan
- [ ] `/deny show` で複数ユーザーの拒否リストが正常に表示されること
- [ ] Stageチャンネルで `/reconnect` が例外なく動作すること
- [ ] 26件以上の辞書エントリをアップロードしてクラッシュしないこと
- [ ] `/dict download` が正常にファイルを返すこと
- [ ] ちょうど125文字の単語が `...` なしで表示されること
- [ ] 再接続ペアのみ残っている状態で `/leave` が適切なメッセージを返すこと