### PR TITLE
実行構成からローカル依存のJRE指定を削除

### DIFF
--- a/.run/runConfigurations/Run Selfhost.run.xml
+++ b/.run/runConfigurations/Run Selfhost.run.xml
@@ -1,7 +1,5 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Selfhost" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="25" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="dev.felnull.itts.Main" />
     <module name="I-TTS.selfhost.main" />
     <option name="VM_PARAMETERS" value="-Xms1G -Xmx1G" />


### PR DESCRIPTION
## Summary
- `Run Selfhost.run.xml` の `ALTERNATIVE_JRE_PATH` / `ALTERNATIVE_JRE_PATH_ENABLED` を削除
- IntelliJ の SDK 名は開発者ごとに異なるため (例: `25` / `corretto-25`)、毎回差分として現れていた
- 削除により Project SDK を使用するようになり、各自が一度 Project SDK を Java 25 に設定すれば衝突しなくなる

## Test plan
- [x] IntelliJ で Run Selfhost 構成を開き、Project SDK で起動できることを確認