### PR TITLE
音声合成失敗時のキャッシュ汚染を修正

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/audio/loader/CachedVoiceTrackLoader.java
+++ b/core/src/main/java/dev/felnull/itts/core/audio/loader/CachedVoiceTrackLoader.java
@@ -50,7 +50,12 @@ public class CachedVoiceTrackLoader implements VoiceTrackLoader, ITTSRuntimeUse 
     @Override
     public CompletableFuture<AudioTrack> load() {
         return getCacheManager().loadOrRestore(hash, streamOpener)
-                .thenApplyAsync(this::loadTack, getAsyncExecutor());
+                .thenApplyAsync(this::loadTack, getAsyncExecutor())
+                .whenComplete((_, throwable) -> {
+                    if (throwable != null) {
+                        dispose();
+                    }
+                });
     }
 
     private AudioTrack loadTack(CacheUseEntry cacheUseEntry) {

--- a/core/src/main/java/dev/felnull/itts/core/audio/loader/CachedVoiceTrackLoader.java
+++ b/core/src/main/java/dev/felnull/itts/core/audio/loader/CachedVoiceTrackLoader.java
@@ -50,7 +50,7 @@ public class CachedVoiceTrackLoader implements VoiceTrackLoader, ITTSRuntimeUse 
     @Override
     public CompletableFuture<AudioTrack> load() {
         return getCacheManager().loadOrRestore(hash, streamOpener)
-                .thenApplyAsync(this::loadTack, getAsyncExecutor())
+                .thenApplyAsync(this::loadTrack, getAsyncExecutor())
                 .whenComplete((_, throwable) -> {
                     if (throwable != null) {
                         dispose();
@@ -58,7 +58,7 @@ public class CachedVoiceTrackLoader implements VoiceTrackLoader, ITTSRuntimeUse 
                 });
     }
 
-    private AudioTrack loadTack(CacheUseEntry cacheUseEntry) {
+    private AudioTrack loadTrack(CacheUseEntry cacheUseEntry) {
         cacheEntry.set(cacheUseEntry);
         VoiceAudioManager vam = getVoiceAudioManager();
         AtomicReference<AudioTrack> retTrack = new AtomicReference<>();

--- a/core/src/main/java/dev/felnull/itts/core/cache/CacheManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/cache/CacheManager.java
@@ -30,6 +30,11 @@ public class CacheManager implements ITTSRuntimeUse {
     private static final File LOCAL_CACHE_FOLDER = new File("./tmp");
 
     /**
+     * 合成音声が空の場合の例外メッセージ
+     */
+    private static final String EMPTY_AUDIO_MESSAGE = "Synthesized audio data is empty";
+
+    /**
      * 保存済みローカルキャッシュ
      */
     private final Map<HashCode, CompletableFuture<LocalCache>> localCaches = new ConcurrentHashMap<>();
@@ -75,62 +80,92 @@ public class CacheManager implements ITTSRuntimeUse {
     }
 
     private CompletableFuture<LocalCache> createLocalCache(HashCode key, StreamOpener loadOpener) {
-        CompletableFuture<File> cf;
         File lcFile = getLocalCacheFile(key);
 
-        if (globalCacheAccessFactory != null) {
-            cf = CompletableFuture.supplyAsync(() -> {
-                try (var gca = globalCacheAccessFactory.get()) {
-                    byte[] data = gca.get(key);
+        CompletableFuture<File> cf = globalCacheAccessFactory != null
+                ? createViaGlobalCache(key, lcFile, loadOpener)
+                : createViaLocalSource(lcFile, loadOpener);
 
-                    if (data == null) {
-                        gca.lock(key);
-                        try {
-                            data = gca.get(key);
-                            if (data == null) {
-                                try (var in = new BufferedInputStream(loadOpener.openStream())) {
-                                    data = in.readAllBytes();
-                                }
+        return cf.thenApplyAsync((file) -> new LocalCache(key, file), getAsyncExecutor());
+    }
 
-                                if (data.length == 0) {
-                                    throw new IOException("Synthesized audio data is empty");
-                                }
+    /**
+     * グローバルキャッシュ経由でローカルキャッシュファイルを生成する
+     *
+     * @param key        キー
+     * @param lcFile     ローカルキャッシュファイル
+     * @param loadOpener ストリーム生成
+     * @return キャッシュファイルのCompletableFuture
+     */
+    private CompletableFuture<File> createViaGlobalCache(HashCode key, File lcFile, StreamOpener loadOpener) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (var gca = globalCacheAccessFactory.get()) {
+                byte[] data = gca.get(key);
 
-                                gca.set(key, data);
+                if (data == null) {
+                    gca.lock(key);
+                    try {
+                        data = gca.get(key);
+                        if (data == null) {
+                            try (var in = new BufferedInputStream(loadOpener.openStream())) {
+                                data = in.readAllBytes();
                             }
-                        } finally {
-                            gca.unlock(key);
+
+                            validateNonEmpty(data);
+
+                            gca.set(key, data);
                         }
+                    } finally {
+                        gca.unlock(key);
                     }
-
-                    Files.write(lcFile.toPath(), data);
-
-                    return lcFile;
-                } catch (Exception ex) {
-                    throw new RuntimeException(ex);
-                }
-            }, getAsyncExecutor());
-
-        } else {
-            cf = CompletableFuture.supplyAsync(() -> {
-
-                try (var in = loadOpener.openStream(); var out = new FileOutputStream(lcFile)) {
-                    FNDataUtil.inputToOutputBuff(in, out);
-                } catch (IOException | InterruptedException e) {
-                    throw new RuntimeException(e);
                 }
 
-                if (lcFile.length() == 0L) {
-                    if (!lcFile.delete()) {
-                        getITTSLogger().warn("Failed to delete empty cache file: {}", lcFile);
-                    }
-                    throw new RuntimeException(new IOException("Synthesized audio data is empty"));
-                }
+                Files.write(lcFile.toPath(), data);
 
                 return lcFile;
-            }, getAsyncExecutor());
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }, getAsyncExecutor());
+    }
+
+    /**
+     * 合成元ストリームから直接ローカルキャッシュファイルを生成する
+     *
+     * @param lcFile     ローカルキャッシュファイル
+     * @param loadOpener ストリーム生成
+     * @return キャッシュファイルのCompletableFuture
+     */
+    private CompletableFuture<File> createViaLocalSource(File lcFile, StreamOpener loadOpener) {
+        return CompletableFuture.supplyAsync(() -> {
+
+            try (var in = loadOpener.openStream(); var out = new FileOutputStream(lcFile)) {
+                FNDataUtil.inputToOutputBuff(in, out);
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (lcFile.length() == 0L) {
+                if (!lcFile.delete()) {
+                    getITTSLogger().warn("Failed to delete empty cache file: {}", lcFile);
+                }
+                throw new RuntimeException(new IOException(EMPTY_AUDIO_MESSAGE));
+            }
+
+            return lcFile;
+        }, getAsyncExecutor());
+    }
+
+    /**
+     * 合成音声データが空でないことを検証する
+     *
+     * @param data 検証対象データ
+     * @throws IOException データが空の場合
+     */
+    private static void validateNonEmpty(byte[] data) throws IOException {
+        if (data.length == 0) {
+            throw new IOException(EMPTY_AUDIO_MESSAGE);
         }
-        return cf.thenApplyAsync((file) -> new LocalCache(key, file), getAsyncExecutor());
     }
 
     private File getLocalCacheFile(HashCode hashCode) {

--- a/core/src/main/java/dev/felnull/itts/core/cache/CacheManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/cache/CacheManager.java
@@ -63,8 +63,15 @@ public class CacheManager implements ITTSRuntimeUse {
      * @return キャッシュエントリのCompletableFuture
      */
     public CompletableFuture<CacheUseEntry> loadOrRestore(@NotNull HashCode key, @NotNull StreamOpener loadOpener) {
-        return localCaches.computeIfAbsent(key, ky -> createLocalCache(ky, loadOpener))
-                .thenApplyAsync(LocalCache::restore, getAsyncExecutor());
+        CompletableFuture<LocalCache> cache = localCaches.computeIfAbsent(key, ky -> createLocalCache(ky, loadOpener));
+
+        cache.whenComplete((_, throwable) -> {
+            if (throwable != null) {
+                localCaches.remove(key, cache);
+            }
+        });
+
+        return cache.thenApplyAsync(LocalCache::restore, getAsyncExecutor());
     }
 
     private CompletableFuture<LocalCache> createLocalCache(HashCode key, StreamOpener loadOpener) {
@@ -78,16 +85,22 @@ public class CacheManager implements ITTSRuntimeUse {
 
                     if (data == null) {
                         gca.lock(key);
+                        try {
+                            data = gca.get(key);
+                            if (data == null) {
+                                try (var in = new BufferedInputStream(loadOpener.openStream())) {
+                                    data = in.readAllBytes();
+                                }
 
-                        data = gca.get(key);
-                        if (data == null) {
-                            try (var in = new BufferedInputStream(loadOpener.openStream());) {
-                                data = in.readAllBytes();
+                                if (data.length == 0) {
+                                    throw new IOException("Synthesized audio data is empty");
+                                }
+
+                                gca.set(key, data);
                             }
-                            gca.set(key, data);
+                        } finally {
+                            gca.unlock(key);
                         }
-
-                        gca.unlock(key);
                     }
 
                     Files.write(lcFile.toPath(), data);
@@ -105,6 +118,13 @@ public class CacheManager implements ITTSRuntimeUse {
                     FNDataUtil.inputToOutputBuff(in, out);
                 } catch (IOException | InterruptedException e) {
                     throw new RuntimeException(e);
+                }
+
+                if (lcFile.length() == 0L) {
+                    if (!lcFile.delete()) {
+                        getITTSLogger().warn("Failed to delete empty cache file: {}", lcFile);
+                    }
+                    throw new RuntimeException(new IOException("Synthesized audio data is empty"));
                 }
 
                 return lcFile;
@@ -125,7 +145,11 @@ public class CacheManager implements ITTSRuntimeUse {
     protected void disposeCache(HashCode hashCode) {
         CompletableFuture<LocalCache> lc = localCaches.remove(hashCode);
         if (lc != null) {
-            lc.thenAcceptAsync(LocalCache::dispose, getAsyncExecutor());
+            lc.thenAcceptAsync(LocalCache::dispose, getAsyncExecutor())
+                    .exceptionally(throwable -> {
+                        getITTSLogger().error("Failed to dispose cache", throwable);
+                        return null;
+                    });
         }
     }
 }

--- a/core/src/main/java/dev/felnull/itts/core/cache/CacheManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/cache/CacheManager.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 /**
@@ -38,6 +39,11 @@ public class CacheManager implements ITTSRuntimeUse {
      * 保存済みローカルキャッシュ
      */
     private final Map<HashCode, CompletableFuture<LocalCache>> localCaches = new ConcurrentHashMap<>();
+
+    /**
+     * ローカルキャッシュファイルの世代識別用カウンタ
+     */
+    private final AtomicLong localCacheFileCounter = new AtomicLong();
 
     /**
      * グローバルキャッシュアクセスの取得
@@ -80,7 +86,7 @@ public class CacheManager implements ITTSRuntimeUse {
     }
 
     private CompletableFuture<LocalCache> createLocalCache(HashCode key, StreamOpener loadOpener) {
-        File lcFile = getLocalCacheFile(key);
+        File lcFile = localCacheFile(key, localCacheFileCounter.getAndIncrement());
 
         CompletableFuture<File> cf = globalCacheAccessFactory != null
                 ? createViaGlobalCache(key, lcFile, loadOpener)
@@ -119,6 +125,8 @@ public class CacheManager implements ITTSRuntimeUse {
                         gca.unlock(key);
                     }
                 }
+
+                validateNonEmpty(data);
 
                 Files.write(lcFile.toPath(), data);
 
@@ -168,8 +176,16 @@ public class CacheManager implements ITTSRuntimeUse {
         }
     }
 
-    private File getLocalCacheFile(HashCode hashCode) {
-        return new File(LOCAL_CACHE_FOLDER, hashCode.toString());
+    /**
+     * ハッシュコードと世代番号からローカルキャッシュファイルのパスを構築する
+     * 世代番号が異なれば同一キーでも異なるパスになり破棄と再生成の競合を防ぐ
+     *
+     * @param hashCode   キャッシュのキー用ハッシュコード
+     * @param generation 世代番号
+     * @return ローカルキャッシュファイル
+     */
+    static File localCacheFile(HashCode hashCode, long generation) {
+        return new File(LOCAL_CACHE_FOLDER, hashCode + "-" + generation);
     }
 
     /**

--- a/core/src/main/java/dev/felnull/itts/core/cache/LocalCache.java
+++ b/core/src/main/java/dev/felnull/itts/core/cache/LocalCache.java
@@ -89,7 +89,7 @@ public class LocalCache implements ITTSRuntimeUse {
      */
     protected void dispose() {
         destroy.set(true);
-        if (file.exists() && file.delete()) {
+        if (file.exists() && !file.delete()) {
             throw new RuntimeException("Failed to delete file");
         }
     }

--- a/core/src/test/java/dev/felnull/itts/core/cache/CacheManagerTest.java
+++ b/core/src/test/java/dev/felnull/itts/core/cache/CacheManagerTest.java
@@ -1,0 +1,39 @@
+package dev.felnull.itts.core.cache;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @description CacheManagerのテスト
+ */
+class CacheManagerTest {
+
+    @Test
+    @DisplayName("同一キーでも世代番号が異なれば一意なキャッシュファイルパスを返す")
+    void localCacheFile_differentGenerations_returnsUniquePaths() {
+        HashCode key = Hashing.sha256().hashString("same-key", StandardCharsets.UTF_8);
+
+        File first = CacheManager.localCacheFile(key, 0L);
+        File second = CacheManager.localCacheFile(key, 1L);
+
+        assertNotEquals(first, second);
+    }
+
+    @Test
+    @DisplayName("キャッシュファイル名はキーのハッシュを接頭辞に持つ")
+    void localCacheFile_keepsHashPrefix() {
+        HashCode key = Hashing.sha256().hashString("same-key", StandardCharsets.UTF_8);
+
+        File file = CacheManager.localCacheFile(key, 0L);
+
+        assertTrue(file.getName().startsWith(key.toString()));
+    }
+}


### PR DESCRIPTION
## Summary

音声合成に失敗したテキストが、Bot再起動まで永久に無音になる問題(キャッシュ汚染)を修正する。`updateQueue()` が該当メッセージをスキップするためBot全体は停止しないが、繰り返し使う定型句が一度のタイムアウト等で無言化していた。

### 失敗時のキャッシュ汚染修正

- **失敗Futureの居残り解消**: 例外完了した `CompletableFuture` が `localCaches` に残り続け、同一 (エンジン+テキスト+話者) ハッシュが永久失敗していた問題を修正。`whenComplete` で例外時に条件付き `remove` し再合成を可能にする
- **空音声のキャッシュ防止**: 合成結果が空 (0バイト) の場合はキャッシュせず例外として扱う
- **useLockの解放漏れ修正**: ロード失敗時に `CachedVoiceTrackLoader.dispose()` を呼び `useLock` を解放。これがないと `useLockCount` が減らず、空キャッシュがタイムアウト破棄もされず残っていた
- **グローバルキャッシュのロック確実化**: `lock`/`unlock` を try/finally で囲み、途中例外時のロックリークを防ぐ (将来のRedis実装向け)
- **LocalCache.dispose の逆ロジック修正**: 削除"成功"時に例外を投げていた条件を、削除"失敗"時のみに修正
- **例外の握りつぶし解消**: キャッシュ破棄時の例外を `exceptionally` でログ出力

### 破棄と再生成の競合修正 (追加)

- **キャッシュファイルの世代衝突修正**: 決定論的だったローカルキャッシュファイルパス (`<hash>`) を世代番号付き (`<hash>-<世代>`) に変更。TTL破棄中の `dispose()` の `delete` が、同一キーで再生成された新世代のファイルを削除してしまう競合を防ぐ
- **グローバルキャッシュ ヒット経路の空データ検証**: 既存の空検証は新規合成パスのみだったため、`gca.get` が既存の空エントリ (旧バージョンや別インスタンスが残した0バイト) を返すヒット経路でも `Files.write` 直前に検証を追加
- **テスト容易化**: ファイルパス構築を副作用のない static メソッド `localCacheFile` へ切り出し、キャッシュフォルダ削除を伴わずに命名規則を検証可能にする

### テスト

- `CacheManagerTest` を追加。世代番号が異なれば一意なパスを返すこと、ファイル名がキーのハッシュを接頭辞に持つことを検証
