### PR TITLE
統計のボイスカテゴリをボイステーブルで紐づけるよう修正

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/statistics/dao/StatisticsDAO.java
+++ b/core/src/main/java/dev/felnull/itts/core/statistics/dao/StatisticsDAO.java
@@ -48,11 +48,11 @@ public interface StatisticsDAO {
     ServerKeyTable serverKeyTable();
 
     /**
-     * ボイスタイプキーテーブルを取得
+     * ボイスタイプテーブルを取得
      *
      * @return テーブルインスタンス
      */
-    VoiceTypeKeyTable voiceTypeKeyTable();
+    VoiceTypeTable voiceTypeTable();
 
     /**
      * ボイスカテゴリキーテーブルを取得
@@ -155,9 +155,41 @@ public interface StatisticsDAO {
     }
 
     /**
-     * ボイスタイプキーテーブル
+     * ボイスタイプテーブル
+     * 名前とボイスカテゴリキーIDの組でボイスタイプを一意に管理する
      */
-    interface VoiceTypeKeyTable extends KeyTable<String> {
+    interface VoiceTypeTable extends Table {
+
+        /**
+         * 名前とカテゴリキーIDからIDを取得
+         *
+         * @param connection    コネクション
+         * @param name          ボイスタイプ名
+         * @param categoryKeyId ボイスカテゴリキーID 未指定の場合はTTSCountTable.UNKNOWN_VOICE_KEY_ID
+         * @return ボイスタイプキーID
+         * @throws SQLException エラー
+         */
+        OptionalInt selectId(@NotNull Connection connection, @NotNull String name, int categoryKeyId) throws SQLException;
+
+        /**
+         * IDから名前を取得
+         *
+         * @param connection コネクション
+         * @param keyId      ボイスタイプキーID
+         * @return ボイスタイプ名
+         * @throws SQLException エラー
+         */
+        Optional<String> selectName(@NotNull Connection connection, int keyId) throws SQLException;
+
+        /**
+         * 指定された名前とカテゴリキーIDの組が存在しなければ追加する
+         *
+         * @param connection    コネクション
+         * @param name          ボイスタイプ名
+         * @param categoryKeyId ボイスカテゴリキーID 未指定の場合はTTSCountTable.UNKNOWN_VOICE_KEY_ID
+         * @throws SQLException エラー
+         */
+        void insertKeyIfNotExists(@NotNull Connection connection, @NotNull String name, int categoryKeyId) throws SQLException;
     }
 
     /**
@@ -179,21 +211,19 @@ public interface StatisticsDAO {
         /**
          * 指定日のカウントを増分する
          *
-         * @param connection         コネクション
-         * @param botKeyId           BOTキーID
-         * @param serverKeyId        サーバーキーID
-         * @param voiceTypeKeyId     ボイスタイプキーID 未指定の場合はUNKNOWN_VOICE_KEY_ID
-         * @param voiceCategoryKeyId ボイスカテゴリキーID 未指定の場合はUNKNOWN_VOICE_KEY_ID
-         * @param date               集計日
-         * @param charDelta          文字数の増分
-         * @param messageDelta       メッセージ数の増分
+         * @param connection     コネクション
+         * @param botKeyId       BOTキーID
+         * @param serverKeyId    サーバーキーID
+         * @param voiceTypeKeyId ボイスタイプキーID 未指定の場合はUNKNOWN_VOICE_KEY_ID
+         * @param date           集計日
+         * @param charDelta      文字数の増分
+         * @param messageDelta   メッセージ数の増分
          * @throws SQLException エラー
          */
         void incrementCount(@NotNull Connection connection,
                             int botKeyId,
                             int serverKeyId,
                             int voiceTypeKeyId,
-                            int voiceCategoryKeyId,
                             @NotNull LocalDate date,
                             long charDelta,
                             long messageDelta) throws SQLException;
@@ -202,13 +232,12 @@ public interface StatisticsDAO {
          * 指定条件のカウントを集計して取得する
          * サーバーやボイスにnullを渡すとそのフィルタを無視する
          *
-         * @param connection         コネクション
-         * @param botKeyId           BOTキーID
-         * @param serverKeyId        サーバーキーIDフィルタ nullで全サーバー集計
-         * @param voiceTypeKeyId     ボイスタイプキーIDフィルタ nullで全ボイス集計
-         * @param voiceCategoryKeyId ボイスカテゴリキーIDフィルタ nullで全カテゴリ集計
-         * @param from               開始日 nullで下限なし
-         * @param to                 終了日 nullで上限なし
+         * @param connection     コネクション
+         * @param botKeyId       BOTキーID
+         * @param serverKeyId    サーバーキーIDフィルタ nullで全サーバー集計
+         * @param voiceTypeKeyId ボイスタイプキーIDフィルタ nullで全ボイス集計
+         * @param from           開始日 nullで下限なし
+         * @param to             終了日 nullで上限なし
          * @return 文字数とメッセージ数の合計
          * @throws SQLException エラー
          */
@@ -217,7 +246,6 @@ public interface StatisticsDAO {
                              int botKeyId,
                              @Nullable Integer serverKeyId,
                              @Nullable Integer voiceTypeKeyId,
-                             @Nullable Integer voiceCategoryKeyId,
                              @Nullable LocalDate from,
                              @Nullable LocalDate to) throws SQLException;
     }

--- a/core/src/main/java/dev/felnull/itts/core/statistics/dao/impl/MySQLStatisticsDAO.java
+++ b/core/src/main/java/dev/felnull/itts/core/statistics/dao/impl/MySQLStatisticsDAO.java
@@ -32,9 +32,9 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
     private final ServerKeyTable serverKeyTable = new ServerKeyTableImpl();
 
     /**
-     * ボイスタイプキーテーブルのインスタンス
+     * ボイスタイプテーブルのインスタンス
      */
-    private final VoiceTypeKeyTable voiceTypeKeyTable = new VoiceTypeKeyTableImpl();
+    private final VoiceTypeTable voiceTypeTable = new VoiceTypeTableImpl();
 
     /**
      * ボイスカテゴリキーテーブルのインスタンス
@@ -109,8 +109,8 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
     }
 
     @Override
-    public VoiceTypeKeyTable voiceTypeKeyTable() {
-        return voiceTypeKeyTable;
+    public VoiceTypeTable voiceTypeTable() {
+        return voiceTypeTable;
     }
 
     @Override
@@ -260,14 +260,14 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
     }
 
     /**
-     * ボイスタイプキーテーブルの実装
+     * ボイスタイプテーブルの実装
      */
-    private final class VoiceTypeKeyTableImpl implements VoiceTypeKeyTable {
+    private final class VoiceTypeTableImpl implements VoiceTypeTable {
 
         @Override
-        public Optional<String> selectKey(@NotNull Connection connection, int keyId) throws SQLException {
+        public Optional<String> selectName(@NotNull Connection connection, int keyId) throws SQLException {
             @Language("MySQL")
-            String sql = "select name from voice_type_key where id = ? limit 1;";
+            String sql = "select name from voice_type where id = ? limit 1;";
 
             try (PreparedStatement statement = connection.prepareStatement(sql)) {
                 statement.setInt(1, keyId);
@@ -282,12 +282,13 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
         }
 
         @Override
-        public OptionalInt selectId(@NotNull Connection connection, @NotNull String key) throws SQLException {
+        public OptionalInt selectId(@NotNull Connection connection, @NotNull String name, int categoryKeyId) throws SQLException {
             @Language("MySQL")
-            String sql = "select id from voice_type_key where name = ? limit 1;";
+            String sql = "select id from voice_type where name = ? and voice_category_id = ? limit 1;";
 
             try (PreparedStatement statement = connection.prepareStatement(sql)) {
-                statement.setString(1, key);
+                statement.setString(1, name);
+                statement.setInt(2, categoryKeyId);
 
                 try (ResultSet rs = statement.executeQuery()) {
                     if (rs.next()) {
@@ -299,16 +300,18 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
         }
 
         @Override
-        public void insertKeyIfNotExists(@NotNull Connection connection, @NotNull String key) throws SQLException {
+        public void insertKeyIfNotExists(@NotNull Connection connection, @NotNull String name, int categoryKeyId) throws SQLException {
             @Language("MySQL")
             String sql = """
-                    insert into voice_type_key(name)
-                    select ? where not exists(select * from voice_type_key where name = ?);
+                    insert into voice_type(name, voice_category_id)
+                    select ?, ? where not exists(select * from voice_type where name = ? and voice_category_id = ?);
                     """;
 
             try (PreparedStatement statement = connection.prepareStatement(sql)) {
-                statement.setString(1, key);
-                statement.setString(2, key);
+                statement.setString(1, name);
+                statement.setInt(2, categoryKeyId);
+                statement.setString(3, name);
+                statement.setInt(4, categoryKeyId);
                 statement.execute();
             }
         }
@@ -317,9 +320,12 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
         public void createTableIfNotExists(@NotNull Connection connection) throws SQLException {
             @Language("MySQL")
             String sql = """
-                    create table if not exists voice_type_key(
+                    create table if not exists voice_type(
                         id integer not null primary key auto_increment,
-                        name varchar(75) not null unique
+                        name varchar(75) not null,
+                        voice_category_id integer not null default 0,
+
+                        unique(name, voice_category_id)
                     );
                     """;
 
@@ -409,12 +415,11 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
                         bot_id integer not null,
                         server_id integer not null,
                         voice_type_id integer not null default 0,
-                        voice_category_id integer not null default 0,
                         target_date date not null,
                         spoken_char_count bigint not null default 0,
                         spoken_message_count bigint not null default 0,
 
-                        unique(bot_id, server_id, voice_type_id, voice_category_id, target_date),
+                        unique(bot_id, server_id, voice_type_id, target_date),
                         foreign key (bot_id) references bot_key(id),
                         foreign key (server_id) references server_key(id)
                     );
@@ -428,14 +433,13 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
                                    int botKeyId,
                                    int serverKeyId,
                                    int voiceTypeKeyId,
-                                   int voiceCategoryKeyId,
                                    @NotNull LocalDate date,
                                    long charDelta,
                                    long messageDelta) throws SQLException {
             @Language("MySQL")
             String sql = """
-                    insert into tts_count_data(bot_id, server_id, voice_type_id, voice_category_id, target_date, spoken_char_count, spoken_message_count)
-                    values (?, ?, ?, ?, ?, ?, ?)
+                    insert into tts_count_data(bot_id, server_id, voice_type_id, target_date, spoken_char_count, spoken_message_count)
+                    values (?, ?, ?, ?, ?, ?)
                     on duplicate key update
                         spoken_char_count = spoken_char_count + values(spoken_char_count),
                         spoken_message_count = spoken_message_count + values(spoken_message_count)
@@ -445,10 +449,9 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
                 statement.setInt(1, botKeyId);
                 statement.setInt(2, serverKeyId);
                 statement.setInt(3, voiceTypeKeyId);
-                statement.setInt(4, voiceCategoryKeyId);
-                statement.setString(5, date.toString());
-                statement.setLong(6, charDelta);
-                statement.setLong(7, messageDelta);
+                statement.setString(4, date.toString());
+                statement.setLong(5, charDelta);
+                statement.setLong(6, messageDelta);
                 statement.execute();
             }
         }
@@ -458,7 +461,6 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
                                              int botKeyId,
                                              @Nullable Integer serverKeyId,
                                              @Nullable Integer voiceTypeKeyId,
-                                             @Nullable Integer voiceCategoryKeyId,
                                              @Nullable LocalDate from,
                                              @Nullable LocalDate to) throws SQLException {
             StringBuilder where = new StringBuilder("bot_id = ?");
@@ -472,10 +474,6 @@ class MySQLStatisticsDAO extends BaseStatisticsDAO {
             if (voiceTypeKeyId != null) {
                 where.append(" and voice_type_id = ?");
                 params.add(voiceTypeKeyId);
-            }
-            if (voiceCategoryKeyId != null) {
-                where.append(" and voice_category_id = ?");
-                params.add(voiceCategoryKeyId);
             }
             if (from != null) {
                 where.append(" and target_date >= ?");

--- a/core/src/main/java/dev/felnull/itts/core/statistics/dao/impl/SQLiteStatisticsDAO.java
+++ b/core/src/main/java/dev/felnull/itts/core/statistics/dao/impl/SQLiteStatisticsDAO.java
@@ -34,9 +34,9 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
     private final ServerKeyTable serverKeyTable = new ServerKeyTableImpl();
 
     /**
-     * ボイスタイプキーテーブルのインスタンス
+     * ボイスタイプテーブルのインスタンス
      */
-    private final VoiceTypeKeyTable voiceTypeKeyTable = new VoiceTypeKeyTableImpl();
+    private final VoiceTypeTable voiceTypeTable = new VoiceTypeTableImpl();
 
     /**
      * ボイスカテゴリキーテーブルのインスタンス
@@ -99,8 +99,8 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
     }
 
     @Override
-    public VoiceTypeKeyTable voiceTypeKeyTable() {
-        return voiceTypeKeyTable;
+    public VoiceTypeTable voiceTypeTable() {
+        return voiceTypeTable;
     }
 
     @Override
@@ -250,14 +250,14 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
     }
 
     /**
-     * ボイスタイプキーテーブルの実装
+     * ボイスタイプテーブルの実装
      */
-    private final class VoiceTypeKeyTableImpl implements VoiceTypeKeyTable {
+    private final class VoiceTypeTableImpl implements VoiceTypeTable {
 
         @Override
-        public Optional<String> selectKey(@NotNull Connection connection, int keyId) throws SQLException {
+        public Optional<String> selectName(@NotNull Connection connection, int keyId) throws SQLException {
             @Language("SQLite")
-            String sql = "select name from voice_type_key where id = ? limit 1;";
+            String sql = "select name from voice_type where id = ? limit 1;";
 
             try (PreparedStatement statement = connection.prepareStatement(sql)) {
                 statement.setInt(1, keyId);
@@ -272,12 +272,13 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
         }
 
         @Override
-        public OptionalInt selectId(@NotNull Connection connection, @NotNull String key) throws SQLException {
+        public OptionalInt selectId(@NotNull Connection connection, @NotNull String name, int categoryKeyId) throws SQLException {
             @Language("SQLite")
-            String sql = "select id from voice_type_key where name = ? limit 1;";
+            String sql = "select id from voice_type where name = ? and voice_category_id = ? limit 1;";
 
             try (PreparedStatement statement = connection.prepareStatement(sql)) {
-                statement.setString(1, key);
+                statement.setString(1, name);
+                statement.setInt(2, categoryKeyId);
 
                 try (ResultSet rs = statement.executeQuery()) {
                     if (rs.next()) {
@@ -289,16 +290,18 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
         }
 
         @Override
-        public void insertKeyIfNotExists(@NotNull Connection connection, @NotNull String key) throws SQLException {
+        public void insertKeyIfNotExists(@NotNull Connection connection, @NotNull String name, int categoryKeyId) throws SQLException {
             @Language("SQLite")
             String sql = """
-                    insert into voice_type_key(name)
-                    select ? where not exists(select * from voice_type_key where name = ?);
+                    insert into voice_type(name, voice_category_id)
+                    select ?, ? where not exists(select * from voice_type where name = ? and voice_category_id = ?);
                     """;
 
             try (PreparedStatement statement = connection.prepareStatement(sql)) {
-                statement.setString(1, key);
-                statement.setString(2, key);
+                statement.setString(1, name);
+                statement.setInt(2, categoryKeyId);
+                statement.setString(3, name);
+                statement.setInt(4, categoryKeyId);
                 statement.execute();
             }
         }
@@ -307,9 +310,12 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
         public void createTableIfNotExists(@NotNull Connection connection) throws SQLException {
             @Language("SQLite")
             String sql = """
-                    create table if not exists voice_type_key(
+                    create table if not exists voice_type(
                         id integer not null primary key autoincrement,
-                        name varchar(75) not null unique
+                        name varchar(75) not null,
+                        voice_category_id integer not null default 0,
+
+                        unique(name, voice_category_id)
                     );
                     """;
 
@@ -399,12 +405,11 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
                         bot_id integer not null,
                         server_id integer not null,
                         voice_type_id integer not null default 0,
-                        voice_category_id integer not null default 0,
                         target_date date not null,
                         spoken_char_count bigint not null default 0,
                         spoken_message_count bigint not null default 0,
 
-                        unique(bot_id, server_id, voice_type_id, voice_category_id, target_date),
+                        unique(bot_id, server_id, voice_type_id, target_date),
                         foreign key (bot_id) references bot_key(id),
                         foreign key (server_id) references server_key(id)
                     );
@@ -418,15 +423,14 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
                                    int botKeyId,
                                    int serverKeyId,
                                    int voiceTypeKeyId,
-                                   int voiceCategoryKeyId,
                                    @NotNull LocalDate date,
                                    long charDelta,
                                    long messageDelta) throws SQLException {
             @Language("SQLite")
             String sql = """
-                    insert into tts_count_data(bot_id, server_id, voice_type_id, voice_category_id, target_date, spoken_char_count, spoken_message_count)
-                    values (?, ?, ?, ?, ?, ?, ?)
-                    on conflict(bot_id, server_id, voice_type_id, voice_category_id, target_date) do update set
+                    insert into tts_count_data(bot_id, server_id, voice_type_id, target_date, spoken_char_count, spoken_message_count)
+                    values (?, ?, ?, ?, ?, ?)
+                    on conflict(bot_id, server_id, voice_type_id, target_date) do update set
                         spoken_char_count = spoken_char_count + excluded.spoken_char_count,
                         spoken_message_count = spoken_message_count + excluded.spoken_message_count
                     """;
@@ -435,10 +439,9 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
                 statement.setInt(1, botKeyId);
                 statement.setInt(2, serverKeyId);
                 statement.setInt(3, voiceTypeKeyId);
-                statement.setInt(4, voiceCategoryKeyId);
-                statement.setString(5, date.toString());
-                statement.setLong(6, charDelta);
-                statement.setLong(7, messageDelta);
+                statement.setString(4, date.toString());
+                statement.setLong(5, charDelta);
+                statement.setLong(6, messageDelta);
                 statement.execute();
             }
         }
@@ -448,7 +451,6 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
                                              int botKeyId,
                                              @Nullable Integer serverKeyId,
                                              @Nullable Integer voiceTypeKeyId,
-                                             @Nullable Integer voiceCategoryKeyId,
                                              @Nullable LocalDate from,
                                              @Nullable LocalDate to) throws SQLException {
             StringBuilder where = new StringBuilder("bot_id = ?");
@@ -462,10 +464,6 @@ class SQLiteStatisticsDAO extends BaseStatisticsDAO {
             if (voiceTypeKeyId != null) {
                 where.append(" and voice_type_id = ?");
                 params.add(voiceTypeKeyId);
-            }
-            if (voiceCategoryKeyId != null) {
-                where.append(" and voice_category_id = ?");
-                params.add(voiceCategoryKeyId);
             }
             if (from != null) {
                 where.append(" and target_date >= ?");

--- a/core/src/main/java/dev/felnull/itts/core/statistics/repository/impl/StatisticsRepositoryImpl.java
+++ b/core/src/main/java/dev/felnull/itts/core/statistics/repository/impl/StatisticsRepositoryImpl.java
@@ -36,9 +36,9 @@ public final class StatisticsRepositoryImpl implements StatisticsRepository {
     private final KeyIdCache<Long> serverKeyCache = new KeyIdCache<>(StatisticsDAO::serverKeyTable, 1000);
 
     /**
-     * ボイスタイプキーのキャッシュ
+     * ボイスタイプのキャッシュ
      */
-    private final KeyIdCache<String> voiceTypeKeyCache = new KeyIdCache<>(StatisticsDAO::voiceTypeKeyTable, 100);
+    private final VoiceTypeIdCache voiceTypeCache = new VoiceTypeIdCache(100);
 
     /**
      * ボイスカテゴリキーのキャッシュ
@@ -80,8 +80,8 @@ public final class StatisticsRepositoryImpl implements StatisticsRepository {
         try (Connection con = dao.getConnection()) {
             dao.botKeyTable().createTableIfNotExists(con);
             dao.serverKeyTable().createTableIfNotExists(con);
-            dao.voiceTypeKeyTable().createTableIfNotExists(con);
             dao.voiceCategoryKeyTable().createTableIfNotExists(con);
+            dao.voiceTypeTable().createTableIfNotExists(con);
             dao.ttsCountTable().createTableIfNotExists(con);
         } catch (SQLException e) {
             throw new IllegalStateException("Statistics database initialization failure", e);
@@ -131,14 +131,14 @@ public final class StatisticsRepositoryImpl implements StatisticsRepository {
         try (Connection con = dao.getConnection()) {
             int botKeyId = botKeyCache.getOrInsertId(con, dao, botId);
             int serverKeyId = serverKeyCache.getOrInsertId(con, dao, serverId);
-            int voiceTypeKeyId = voiceTypeId != null
-                    ? voiceTypeKeyCache.getOrInsertId(con, dao, voiceTypeId)
-                    : TTSCountTable.UNKNOWN_VOICE_KEY_ID;
             int voiceCategoryKeyId = voiceCategoryId != null
                     ? voiceCategoryKeyCache.getOrInsertId(con, dao, voiceCategoryId)
                     : TTSCountTable.UNKNOWN_VOICE_KEY_ID;
+            int voiceTypeKeyId = voiceTypeId != null
+                    ? voiceTypeCache.getOrInsertId(con, dao, voiceTypeId, voiceCategoryKeyId)
+                    : TTSCountTable.UNKNOWN_VOICE_KEY_ID;
 
-            dao.ttsCountTable().incrementCount(con, botKeyId, serverKeyId, voiceTypeKeyId, voiceCategoryKeyId, date, charDelta, messageDelta);
+            dao.ttsCountTable().incrementCount(con, botKeyId, serverKeyId, voiceTypeKeyId, date, charDelta, messageDelta);
         } catch (Exception e) {
             fireErrorEvent(e);
             throw new RuntimeException(e);
@@ -165,7 +165,7 @@ public final class StatisticsRepositoryImpl implements StatisticsRepository {
                 serverKeyId = sid.getAsInt();
             }
 
-            return dao.ttsCountTable().sumCount(con, botKeyId.getAsInt(), serverKeyId, null, null, from, to);
+            return dao.ttsCountTable().sumCount(con, botKeyId.getAsInt(), serverKeyId, null, from, to);
         } catch (Exception e) {
             fireErrorEvent(e);
             return TTSCountSum.ZERO;
@@ -215,6 +215,58 @@ public final class StatisticsRepositoryImpl implements StatisticsRepository {
             } else {
                 table.insertKeyIfNotExists(con, key);
                 id = table.selectId(con, key).orElseThrow();
+            }
+            cache.put(key, id);
+            return id;
+        }
+    }
+
+    /**
+     * ボイスタイプの名前とカテゴリキーIDの組
+     *
+     * @param name          ボイスタイプ名
+     * @param categoryKeyId ボイスカテゴリキーID
+     */
+    private record VoiceTypeKey(@NotNull String name, int categoryKeyId) {
+    }
+
+    /**
+     * ボイスタイプIDのキャッシュ
+     * 名前とカテゴリキーIDの組からIDを解決する
+     */
+    private static final class VoiceTypeIdCache {
+
+        /**
+         * キャッシュ本体
+         */
+        private final LoadingCache<VoiceTypeKey, Integer> cache;
+
+        VoiceTypeIdCache(int maxSize) {
+            this.cache = CacheBuilder.newBuilder()
+                    .maximumSize(maxSize)
+                    .build(new CacheLoader<>() {
+                        @Override
+                        public @NotNull Integer load(@NotNull VoiceTypeKey key) {
+                            throw new UnsupportedOperationException("Use getOrInsertId(...) instead");
+                        }
+                    });
+        }
+
+        int getOrInsertId(@NotNull Connection con, @NotNull StatisticsDAO dao, @NotNull String name, int categoryKeyId) throws SQLException {
+            VoiceTypeKey key = new VoiceTypeKey(name, categoryKeyId);
+            Integer cached = cache.getIfPresent(key);
+            if (cached != null) {
+                return cached;
+            }
+
+            StatisticsDAO.VoiceTypeTable table = dao.voiceTypeTable();
+            OptionalInt existing = table.selectId(con, name, categoryKeyId);
+            int id;
+            if (existing.isPresent()) {
+                id = existing.getAsInt();
+            } else {
+                table.insertKeyIfNotExists(con, name, categoryKeyId);
+                id = table.selectId(con, name, categoryKeyId).orElseThrow();
             }
             cache.put(key, id);
             return id;


### PR DESCRIPTION
## Summary
- 統計DBでボイスカテゴリを `tts_count_data` に直接持たせていたのを、ボイス側のテーブルで紐づける構造へ変更
- `voice_type_key` テーブルを `voice_type` へ改名し、`voice_category_id` カラムを追加 (`unique(name, voice_category_id)`)
- `tts_count_data` から `voice_category_id` を削除 (`unique`制約・FKも更新し `voice_type_id` のみ参照)
- `StatisticsDAO` の `VoiceTypeTable` を名前+カテゴリキーIDの組を扱うインターフェースへ再定義、`TTSCountTable` の `incrementCount`/`sumCount` から `voiceCategoryKeyId` 引数を削除
- Repository でカテゴリを先に解決してから `voice_type` を解決する流れに変更し、複合キー用の `VoiceTypeIdCache` を追加
- SQLite/MySQL 両DAO実装を新スキーマへ更新

## Test plan
- [x] `TTSCountStatisticsTest` がグリーン
- [x] `./gradlew :core:build` が BUILD SUCCESSFUL (Checkstyle含む)
- [ ] 既存統計DBからのマイグレーションは未実装 (必要なら別途対応)