### PR TITLE
infoコマンドのサブコマンドをchoicesに変更

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/discord/command/InfoCommand.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/command/InfoCommand.java
@@ -7,9 +7,11 @@ import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionContextType;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
-import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.jetbrains.annotations.NotNull;
@@ -46,14 +48,16 @@ public class InfoCommand extends BaseCommand {
         return Commands.slash("info", "情報を表示")
                 .setContexts(InteractionContextType.GUILD)
                 .setDefaultPermissions(MEMBERS_PERMISSIONS)
-                .addSubcommands(new SubcommandData("about", "BOT情報を表示"))
-                .addSubcommands(new SubcommandData("oss", "OSS情報を表示"))
-                .addSubcommands(new SubcommandData("work", "稼働情報を表示"));
+                .addOptions(new OptionData(OptionType.STRING, "type", "表示する情報の種類", true)
+                        .addChoice("BOT情報", "about")
+                        .addChoice("OSSクレジット", "oss")
+                        .addChoice("稼働情報", "work"));
     }
 
     @Override
     public void commandInteraction(SlashCommandInteractionEvent event) {
-        switch (Objects.requireNonNull(event.getSubcommandName())) {
+        OptionMapping typeOption = Objects.requireNonNull(event.getOption("type"));
+        switch (typeOption.getAsString()) {
             case "about" -> about(event);
             case "oss" -> oss(event);
             case "work" -> work(event);


### PR DESCRIPTION
## Summary
- `/info` のサジェストが about/oss/work の3行で表示されサジェスト一覧を圧迫していたため、`SubcommandData` を `OptionType.STRING` + `addChoice` に置き換え
- Discord 上の `/info` サジェストが1行に集約され、`type` パラメータで about/oss/work を選択する形になる
- ハンドラ側の分岐を `event.getSubcommandName()` から `event.getOption("type").getAsString()` に変更

## Test plan
- [ ] BOT起動後に Discord で `/info` のサジェストが1行のみ表示されることを確認
- [ ] `/info type:BOT情報` で about の Embed が表示されることを確認
- [ ] `/info type:OSSクレジット` で oss の Embed が表示されることを確認
- [ ] `/info type:稼働情報` で work の Embed が表示されることを確認