### PR TITLE
音声スケジューラの破棄処理とキュー同期を修正

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/audio/VoiceAudioScheduler.java
+++ b/core/src/main/java/dev/felnull/itts/core/audio/VoiceAudioScheduler.java
@@ -70,6 +70,7 @@ public class VoiceAudioScheduler extends AudioEventAdapter implements ITTSRuntim
     public void dispose() {
         stop();
         this.audioManager.setSendingHandler(null);
+        this.audioPlayer.destroy();
     }
 
     /**
@@ -106,8 +107,8 @@ public class VoiceAudioScheduler extends AudioEventAdapter implements ITTSRuntim
      * 再生を一時停止
      */
     public void stop() {
-        currentLoaded.set(null);
         audioPlayer.stopTrack();
+        currentLoaded.set(null);
     }
 
     /**
@@ -124,9 +125,11 @@ public class VoiceAudioScheduler extends AudioEventAdapter implements ITTSRuntim
     @Override
     public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
         Pair<LoadedSaidText, Runnable> old = currentLoaded.getAndSet(null);
-        if (old != null) {
+        if (old != null && old.getLeft().getTrack() == track) {
             old.getLeft().setAlreadyUsed(true);
-            old.getRight().run();
+            if (endReason.mayStartNext) {
+                old.getRight().run();
+            }
         }
     }
 }

--- a/core/src/main/java/dev/felnull/itts/core/tts/TTSInstance.java
+++ b/core/src/main/java/dev/felnull/itts/core/tts/TTSInstance.java
@@ -125,22 +125,24 @@ public final class TTSInstance implements ITTSRuntimeUse {
      * 破棄
      */
     public void dispose() {
-        destroyed.set(true);
+        synchronized (updateLock) {
+            destroyed.set(true);
 
-        vcEventSaidRegulator.dispose();
+            vcEventSaidRegulator.dispose();
 
-        saidTextQueue.clear();
+            saidTextQueue.clear();
 
-        while (!loadSaidTextQueue.isEmpty()) {
-            loadSaidTextQueue.poll().dispose();
+            while (!loadSaidTextQueue.isEmpty()) {
+                loadSaidTextQueue.poll().dispose();
+            }
+
+            LoadedSaidTextEntry cst = currentSaidText.get();
+            if (cst != null) {
+                cst.dispose();
+            }
+
+            voiceAudioScheduler.dispose();
         }
-
-        LoadedSaidTextEntry cst = currentSaidText.get();
-        if (cst != null) {
-            cst.dispose();
-        }
-
-        voiceAudioScheduler.dispose();
     }
 
     /**
@@ -156,12 +158,18 @@ public final class TTSInstance implements ITTSRuntimeUse {
         if (overwriteAloud) {
             updateAloud(saidText);
         } else {
-            if (saidText instanceof VCEventSaidText vst && vcEventSaidRegulator.restrict(vst.getMember().getUser().getIdLong(), vst)) {
-                return;
-            }
+            synchronized (updateLock) {
+                if (destroyed.get()) {
+                    return;
+                }
 
-            saidTextQueue.add(saidText);
-            updateQueue();
+                if (saidText instanceof VCEventSaidText vst && vcEventSaidRegulator.restrict(vst.getMember().getUser().getIdLong(), vst)) {
+                    return;
+                }
+
+                saidTextQueue.add(saidText);
+                updateQueue();
+            }
         }
     }
 
@@ -171,37 +179,38 @@ public final class TTSInstance implements ITTSRuntimeUse {
      * @return 飛ばした数
      */
     public int skipAll() {
-        currentReadAloudUUID.set(UUID.randomUUID());
-        voiceAudioScheduler.stop();
+        synchronized (updateLock) {
+            currentReadAloudUUID.set(UUID.randomUUID());
+            voiceAudioScheduler.stop();
 
-        if (overwriteAloud) {
-            LoadedSaidTextEntry lste = currentSaidText.getAndSet(null);
-            if (lste != null) {
-                lste.dispose();
-                return 1;
+            if (overwriteAloud) {
+                LoadedSaidTextEntry lste = currentSaidText.getAndSet(null);
+                if (lste != null) {
+                    lste.dispose();
+                    return 1;
+                }
+            } else {
+                int ct = 0;
+                ct += saidTextQueue.size();
+                saidTextQueue.clear();
+
+                ct += loadSaidTextQueue.size();
+                while (!loadSaidTextQueue.isEmpty()) {
+                    loadSaidTextQueue.poll().dispose();
+                }
+
+                LoadedSaidTextEntry lste = currentSaidText.getAndSet(null);
+                if (lste != null) {
+                    lste.dispose();
+                    ct++;
+                }
+
+                next.compareAndSet(false, true);
+
+                updateQueue();
+
+                return ct;
             }
-        } else {
-            int ct = 0;
-            ct += saidTextQueue.size();
-            saidTextQueue.clear();
-
-            ct += loadSaidTextQueue.size();
-            while (!loadSaidTextQueue.isEmpty()) {
-                loadSaidTextQueue.poll().dispose();
-            }
-
-            LoadedSaidTextEntry lste = currentSaidText.getAndSet(null);
-            if (lste != null) {
-                lste.dispose();
-                ct++;
-            }
-
-            next.compareAndSet(false, true);
-
-            updateQueue();
-
-
-            return ct;
         }
 
         return 0;
@@ -257,7 +266,7 @@ public final class TTSInstance implements ITTSRuntimeUse {
                     currentSaidText.set(null);
                 }
 
-                while (!saidTextQueue.isEmpty()) {
+                while (loadSaidTextQueue.size() < LOAD_COUNT && !saidTextQueue.isEmpty()) {
                     loadSaidTextQueue.add(new LoadedSaidTextEntry(saidTextQueue.poll()));
                 }
             }


### PR DESCRIPTION
## 概要
- 音声スケジューラ破棄時に LavaPlayer の AudioPlayer を破棄するよう修正
- skip / dispose / enqueue 時の TTS キュー操作を同期化
- 再生進行後の音声ロード数が LOAD_COUNT を超えないよう修正

## 確認内容
- [x] ./gradlew test
- [x] ./gradlew build