### PR TITLE
Improve HTTP error handling for voice and domain list requests

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/dict/DomainListManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/dict/DomainListManager.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -24,6 +25,16 @@ public class DomainListManager implements ITTSBaseManager {
     private static final URI IANA_DATA_URI = URI.create("https://data.iana.org/TLD/tlds-alpha-by-domain.txt");
 
     /**
+     * TLDリスト取得のタイムアウト
+     */
+    private static final Duration DOMAIN_LIST_TIMEOUT = Duration.ofSeconds(10);
+
+    /**
+     * TLDリスト取得の最大試行回数
+     */
+    private static final int DOMAIN_LIST_MAX_ATTEMPTS = 3;
+
+    /**
      * 読み込み済みTLDリスト
      */
     private Pattern domainPattern;
@@ -32,25 +43,59 @@ public class DomainListManager implements ITTSBaseManager {
     public @NotNull CompletableFuture<?> init() {
         return CompletableFuture.runAsync(() -> {
             try {
-                HttpClient hc = getNetworkManager().getHttpClient();
-                HttpRequest request = HttpRequest.newBuilder().uri(IANA_DATA_URI).GET().build();
-
-                HttpResponse<String> res = hc.send(request, HttpResponse.BodyHandlers.ofString());
-
-                String processedDomains = res.body().lines()
-                    .filter(line -> !line.startsWith("#"))
-                    .filter(list -> !list.isBlank())
-                    .map(String::trim)
-                    .map(String::toLowerCase)
-                    .map(Pattern::quote)
-                    .collect(Collectors.joining("|"));
-
-                String regex = "\\b[a-zA-Z0-9.-]+\\.(?i:" + processedDomains + ")\\b";
-                domainPattern = Pattern.compile(regex);
+                loadDomainListWithRetry();
             } catch (IOException | InterruptedException e) {
-                getITTSLogger().error("failed to get domain list.");
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                getITTSLogger().error("Failed to get domain list from {}", IANA_DATA_URI, e);
             }
         }, getAsyncExecutor());
+    }
+
+    private void loadDomainListWithRetry() throws IOException, InterruptedException {
+        IOException lastException = null;
+
+        for (int attempt = 1; attempt <= DOMAIN_LIST_MAX_ATTEMPTS; attempt++) {
+            try {
+                loadDomainList();
+                return;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw e;
+            } catch (IOException e) {
+                lastException = e;
+                getITTSLogger().warn("Failed to get domain list from {} ({}/{})", IANA_DATA_URI, attempt, DOMAIN_LIST_MAX_ATTEMPTS, e);
+            }
+        }
+
+        throw new IOException("Failed to get domain list after " + DOMAIN_LIST_MAX_ATTEMPTS + " attempts", lastException);
+    }
+
+    private void loadDomainList() throws IOException, InterruptedException {
+        HttpClient hc = getNetworkManager().getHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(IANA_DATA_URI)
+                .timeout(DOMAIN_LIST_TIMEOUT)
+                .GET()
+                .build();
+
+        HttpResponse<String> res = hc.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (res.statusCode() != 200) {
+            throw new IOException("Domain list API error: HTTP " + res.statusCode());
+        }
+
+        String processedDomains = res.body().lines()
+                .filter(line -> !line.startsWith("#"))
+                .filter(list -> !list.isBlank())
+                .map(String::trim)
+                .map(String::toLowerCase)
+                .map(Pattern::quote)
+                .collect(Collectors.joining("|"));
+
+        String regex = "\\b[a-zA-Z0-9.-]+\\.(?i:" + processedDomains + ")\\b";
+        domainPattern = Pattern.compile(regex);
     }
 
     /**

--- a/core/src/main/java/dev/felnull/itts/core/voice/VoiceHttpUtils.java
+++ b/core/src/main/java/dev/felnull/itts/core/voice/VoiceHttpUtils.java
@@ -1,7 +1,9 @@
 package dev.felnull.itts.core.voice;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.http.HttpTimeoutException;
+import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
@@ -35,5 +37,22 @@ public final class VoiceHttpUtils {
      */
     public static IOException timeoutException(String engineName, String apiName, HttpTimeoutException exception) {
         return new IOException(engineName + " " + apiName + " API timed out after " + SYNTHESIS_TIMEOUT.toSeconds() + " seconds", exception);
+    }
+
+    /**
+     * 返却しないHTTPレスポンスのbodyを閉じる
+     *
+     * @param response HTTPレスポンス
+     */
+    public static void closeBodyQuietly(HttpResponse<InputStream> response) {
+        if (response == null || response.body() == null) {
+            return;
+        }
+
+        try {
+            response.body().close();
+        } catch (IOException ignored) {
+            // エラー応答の破棄に失敗しても元の例外を優先する
+        }
     }
 }

--- a/core/src/main/java/dev/felnull/itts/core/voice/coeiroink/CoeiroinkManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/voice/coeiroink/CoeiroinkManager.java
@@ -122,6 +122,7 @@ public class CoeiroinkManager {
 
         int statusCode = rep.statusCode();
         if (statusCode != 200) {
+            VoiceHttpUtils.closeBodyQuietly(rep);
             throw new IOException(name + " API error: HTTP " + statusCode);
         }
 
@@ -178,6 +179,7 @@ public class CoeiroinkManager {
             int code = res.statusCode();
 
             if (content.isEmpty()) {
+                VoiceHttpUtils.closeBodyQuietly(res);
                 throw new IOException("Content Type does not exist: " + code);
             }
 
@@ -186,6 +188,7 @@ public class CoeiroinkManager {
                 return res.body();
             }
 
+            VoiceHttpUtils.closeBodyQuietly(res);
             throw new IOException("Not audio data: " + code);
         } catch (HttpTimeoutException e) {
             throw VoiceHttpUtils.timeoutException(name, "synthesis", e);

--- a/core/src/main/java/dev/felnull/itts/core/voice/voicetext/VoiceTextManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/voice/voicetext/VoiceTextManager.java
@@ -103,6 +103,7 @@ public class VoiceTextManager implements ITTSRuntimeUse {
         int code = res.statusCode();
 
         if (content.isEmpty()) {
+            VoiceHttpUtils.closeBodyQuietly(res);
             throw new IOException("Content Type does not exist: " + code);
         }
 
@@ -119,6 +120,7 @@ public class VoiceTextManager implements ITTSRuntimeUse {
             }
         }
 
+        VoiceHttpUtils.closeBodyQuietly(res);
         throw new IOException("Not audio data: " + code);
     }
 

--- a/core/src/main/java/dev/felnull/itts/core/voice/voicevox/VoicevoxManager.java
+++ b/core/src/main/java/dev/felnull/itts/core/voice/voicevox/VoicevoxManager.java
@@ -123,6 +123,7 @@ public class VoicevoxManager {
 
         int statusCode = rep.statusCode();
         if (statusCode != 200) {
+            VoiceHttpUtils.closeBodyQuietly(rep);
             throw new IOException(name + " API error: HTTP " + statusCode);
         }
 
@@ -166,6 +167,7 @@ public class VoicevoxManager {
 
             int statusCode = rep.statusCode();
             if (statusCode != 200) {
+                VoiceHttpUtils.closeBodyQuietly(rep);
                 throw new IOException(name + " audio_query API error: HTTP " + statusCode);
             }
 
@@ -209,6 +211,7 @@ public class VoicevoxManager {
             int code = res.statusCode();
 
             if (content.isEmpty()) {
+                VoiceHttpUtils.closeBodyQuietly(res);
                 throw new IOException("Content Type does not exist: " + code);
             }
 
@@ -217,6 +220,7 @@ public class VoicevoxManager {
                 return res.body();
             }
 
+            VoiceHttpUtils.closeBodyQuietly(res);
             throw new IOException("Not audio data: " + code);
         } catch (HttpTimeoutException e) {
             throw VoiceHttpUtils.timeoutException(name, "synthesis", e);


### PR DESCRIPTION
## Summary
- Close voice HTTP response bodies on non-returned error paths
- Add timeout, status validation, retry, and detailed logging to DomainListManager TLD loading
- Re-check broad `catch (Exception e)` usage around voice HTTP paths

## Test plan
- [x] `./gradlew :core:checkstyleMain :core:test --console=plain`