### PR TITLE
Fix libdave log formatting

### DIFF
--- a/core/src/main/java/dev/felnull/itts/core/discord/Bot.java
+++ b/core/src/main/java/dev/felnull/itts/core/discord/Bot.java
@@ -4,6 +4,7 @@ import dev.felnull.itts.core.ITTSRuntimeUse;
 import dev.felnull.itts.core.ImmortalityTimer;
 import dev.felnull.itts.core.discord.command.*;
 import club.minnced.discord.jdave.interop.JDaveSessionFactory;
+import club.minnced.discord.jdave.utils.DaveLogger;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
@@ -41,6 +42,7 @@ public class Bot implements ITTSRuntimeUse {
      * BOTを開始
      */
     public void start() {
+        DaveLogger.init();
         registeringCommands();
 
         this.jda = JDABuilder.createDefault(getConfigManager().getConfig().getBotToken())


### PR DESCRIPTION
## Summary
- Initialize the jdave log sink before JDA creates voice sessions
- Route native libdave MLS messages through the configured SLF4J/Log4j format

## Test plan
- [x] Run `.\gradlew.bat build`